### PR TITLE
feat: keep params on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add capital letter R to reset zoom button
 -   Rename Connect to Substra in code and ci files
 -   Change primary color from teal to blue
+-   Filters are kept when using the refresh button or banner
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add capital letter R to reset zoom button
 -   Rename Connect to Substra in code and ci files
 -   Change primary color from teal to blue
--   Filters are kept when using the refresh button or banner
+-   Keep filtering/ordering setup when refreshing an asset list page
 
 ### Fixed
 

--- a/src/components/RefreshBanner.tsx
+++ b/src/components/RefreshBanner.tsx
@@ -7,6 +7,7 @@ import { RiInformationLine } from 'react-icons/ri';
 
 import useAppSelector from '@/hooks/useAppSelector';
 import useHandleRefresh from '@/hooks/useHandleRefresh';
+import { getUrlSearchParams } from '@/hooks/useLocationWithParams';
 import { listComputePlans } from '@/modules/computePlans/ComputePlansSlice';
 import * as NewsFeedApi from '@/modules/newsFeed/NewsFeedApi';
 import { ACTUALIZE_NEWS_INTERVAL } from '@/modules/newsFeed/NewsFeedUtils';
@@ -19,8 +20,11 @@ const RefreshBanner = (): JSX.Element | null => {
         (state) => state.computePlans.computePlansCallTimestamp
     );
 
+    const urlSearchParams = getUrlSearchParams();
+    const ordering = urlSearchParams.get('ordering') || '';
+
     const handleRefresh = useHandleRefresh(() =>
-        listComputePlans({ page: 1, ordering: '-creation_date' })
+        listComputePlans({ page: 1, ordering: ordering })
     );
 
     useEffect(() => {

--- a/src/components/RefreshBanner.tsx
+++ b/src/components/RefreshBanner.tsx
@@ -21,10 +21,11 @@ const RefreshBanner = (): JSX.Element | null => {
     );
 
     const urlSearchParams = getUrlSearchParams();
+    const page = parseInt(urlSearchParams.get('page') || '1');
     const ordering = urlSearchParams.get('ordering') || '';
 
     const handleRefresh = useHandleRefresh(() =>
-        listComputePlans({ page: 1, ordering: ordering })
+        listComputePlans({ page: page, ordering: ordering })
     );
 
     useEffect(() => {

--- a/src/components/RefreshBanner.tsx
+++ b/src/components/RefreshBanner.tsx
@@ -8,7 +8,6 @@ import { RiInformationLine } from 'react-icons/ri';
 import useAppSelector from '@/hooks/useAppSelector';
 import useFavoriteComputePlans from '@/hooks/useFavoriteComputePlans';
 import useHandleRefresh from '@/hooks/useHandleRefresh';
-import { getUrlSearchParams } from '@/hooks/useLocationWithParams';
 import {
     usePage,
     useMatch,
@@ -19,6 +18,7 @@ import {
     useEndDate,
     useDuration,
     useMetadataString,
+    useOrdering,
 } from '@/hooks/useSyncedState';
 import { listComputePlans } from '@/modules/computePlans/ComputePlansSlice';
 import * as NewsFeedApi from '@/modules/newsFeed/NewsFeedApi';
@@ -36,14 +36,12 @@ const RefreshBanner = (): JSX.Element | null => {
     const { endDateBefore, endDateAfter } = useEndDate();
     const { durationMin, durationMax } = useDuration();
     const [metadata] = useMetadataString();
+    const [ordering] = useOrdering('');
 
     const [refreshAvailable, setRefreshAvailable] = useState(false);
     const computePlansCallTimestamp = useAppSelector(
         (state) => state.computePlans.computePlansCallTimestamp
     );
-
-    const urlSearchParams = getUrlSearchParams();
-    const ordering = urlSearchParams.get('ordering') || '';
 
     const { favorites } = useFavoriteComputePlans();
 

--- a/src/components/RefreshBanner.tsx
+++ b/src/components/RefreshBanner.tsx
@@ -24,8 +24,21 @@ const RefreshBanner = (): JSX.Element | null => {
     const page = parseInt(urlSearchParams.get('page') || '1');
     const ordering = urlSearchParams.get('ordering') || '';
 
+    const filters = {
+        creation_date_after: urlSearchParams.get('creation_date_after'),
+        creation_date_before: urlSearchParams.get('creation_date_before'),
+        duration_max: urlSearchParams.get('duration_max'),
+        duration_min: urlSearchParams.get('duration_min'),
+        end_date_after: urlSearchParams.get('end_date_after'),
+        end_date_before: urlSearchParams.get('end_date_before'),
+        match: urlSearchParams.get('match') || '',
+        metadata: urlSearchParams.get('metadata'),
+        start_date_after: urlSearchParams.get('start_date_after'),
+        start_date_before: urlSearchParams.get('start_date_before'),
+        status: urlSearchParams.get('status')?.split(',') || [],
+    };
     const handleRefresh = useHandleRefresh(() =>
-        listComputePlans({ page: page, ordering: ordering })
+        listComputePlans({ page: page, ordering: ordering, ...filters })
     );
 
     useEffect(() => {

--- a/src/hooks/useHandleRefresh.ts
+++ b/src/hooks/useHandleRefresh.ts
@@ -1,9 +1,7 @@
 import { AsyncThunkAction } from '@reduxjs/toolkit';
-import { useLocation } from 'wouter';
 
 import useAppDispatch from './useAppDispatch';
 import { DispatchWithAutoAbortProps } from './useDispatchWithAutoAbort';
-import { useSetLocationPreserveParams } from './useLocationWithParams';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ActionBuilderT = () => AsyncThunkAction<any, any, any>;
@@ -12,12 +10,9 @@ const useHandleRefresh = (
     actionBuilder: ActionBuilderT,
     dispatchWithAutoAbort?: DispatchWithAutoAbortProps
 ): (() => void) => {
-    const [location] = useLocation();
-    const setLocationPreserveParams = useSetLocationPreserveParams();
     const dispatch = useAppDispatch();
 
     return () => {
-        setLocationPreserveParams(location);
         if (dispatchWithAutoAbort) {
             dispatchWithAutoAbort(actionBuilder());
         } else {

--- a/src/hooks/useHandleRefresh.ts
+++ b/src/hooks/useHandleRefresh.ts
@@ -1,8 +1,9 @@
 import { AsyncThunkAction } from '@reduxjs/toolkit';
+import { useLocation } from 'wouter';
 
 import useAppDispatch from './useAppDispatch';
 import { DispatchWithAutoAbortProps } from './useDispatchWithAutoAbort';
-import { useSetLocationParams } from './useLocationWithParams';
+import { useSetLocationPreserveParams } from './useLocationWithParams';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ActionBuilderT = () => AsyncThunkAction<any, any, any>;
@@ -11,15 +12,12 @@ const useHandleRefresh = (
     actionBuilder: ActionBuilderT,
     dispatchWithAutoAbort?: DispatchWithAutoAbortProps
 ): (() => void) => {
-    const setLocationParams = useSetLocationParams();
+    const [location] = useLocation();
+    const setLocationPreserveParams = useSetLocationPreserveParams();
     const dispatch = useAppDispatch();
 
-    const urlSearchParams = new URLSearchParams();
-    urlSearchParams.set('page', '1');
-    urlSearchParams.set('ordering', '-creation_date');
-
     return () => {
-        setLocationParams(urlSearchParams);
+        setLocationPreserveParams(location);
         if (dispatchWithAutoAbort) {
             dispatchWithAutoAbort(actionBuilder());
         } else {

--- a/src/routes/algos/Algos.tsx
+++ b/src/routes/algos/Algos.tsx
@@ -126,7 +126,18 @@ const Algos = (): JSX.Element => {
                     <RefreshButton
                         loading={algosLoading}
                         dispatchWithAutoAbort={dispatchWithAutoAbort}
-                        actionBuilder={() => listAlgos({})}
+                        actionBuilder={() =>
+                            listAlgos({
+                                page,
+                                ordering,
+                                match,
+                                owner,
+                                creation_date_after: creationDateAfter,
+                                creation_date_before:
+                                    endOfDay(creationDateBefore),
+                                can_process: canProcess,
+                            })
+                        }
                     />
                 </Flex>
                 <TableFilterTags>

--- a/src/routes/computePlans/ComputePlans.tsx
+++ b/src/routes/computePlans/ComputePlans.tsx
@@ -223,6 +223,7 @@ const ComputePlans = (): JSX.Element => {
                                 listComputePlans({
                                     page: page,
                                     ordering: ordering,
+                                    ...filters,
                                 })
                             }
                             dispatchWithAutoAbort={dispatchWithAutoAbort}

--- a/src/routes/computePlans/ComputePlans.tsx
+++ b/src/routes/computePlans/ComputePlans.tsx
@@ -222,7 +222,7 @@ const ComputePlans = (): JSX.Element => {
                             actionBuilder={() =>
                                 listComputePlans({
                                     page: 1,
-                                    ordering: '-creation_date',
+                                    ordering: ordering,
                                 })
                             }
                             dispatchWithAutoAbort={dispatchWithAutoAbort}

--- a/src/routes/computePlans/ComputePlans.tsx
+++ b/src/routes/computePlans/ComputePlans.tsx
@@ -221,7 +221,7 @@ const ComputePlans = (): JSX.Element => {
                             loading={computePlansLoading}
                             actionBuilder={() =>
                                 listComputePlans({
-                                    page: 1,
+                                    page: page,
                                     ordering: ordering,
                                 })
                             }

--- a/src/routes/datasets/Datasets.tsx
+++ b/src/routes/datasets/Datasets.tsx
@@ -137,7 +137,19 @@ const Datasets = (): JSX.Element => {
                     <RefreshButton
                         loading={datasetsLoading}
                         dispatchWithAutoAbort={dispatchWithAutoAbort}
-                        actionBuilder={() => listDatasets({})}
+                        actionBuilder={() =>
+                            listDatasets({
+                                page,
+                                ordering,
+                                match,
+                                owner,
+                                creation_date_after: creationDateAfter,
+                                creation_date_before:
+                                    endOfDay(creationDateBefore),
+                                can_process: canProcess,
+                                can_access_logs: canAccessLogs,
+                            })
+                        }
                     />
                 </Flex>
                 <TableFilterTags>


### PR DESCRIPTION
From @maeldebon 

### Description
I updated `useHandleRefresh` to keep parameters on refresh.
Refresh banner is now getting ordering from url params in order to be able to sort compute plans properly.
