### PR TITLE
chore: text with middle ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Users management v1
 -   Added license file
 -   Removed references to close-source items
+-   Component with ellipsis in the middle
 
 ### Changed
 

--- a/src/components/TextWithMiddleEllipsis.tsx
+++ b/src/components/TextWithMiddleEllipsis.tsx
@@ -1,0 +1,37 @@
+import { Flex, Text, TextProps } from '@chakra-ui/react';
+
+interface TextWithMiddleEllipsisProps extends TextProps {
+    text: string;
+    charsAfterEllipsis: number;
+}
+const TextWithMiddleEllipsis = ({
+    text,
+    charsAfterEllipsis,
+    width,
+    ...props
+}: TextWithMiddleEllipsisProps) => {
+    const before = text.slice(0, text.length - charsAfterEllipsis);
+    const after = text.slice(text.length - charsAfterEllipsis);
+    return (
+        <Flex width={width} overflow="hidden" whiteSpace="nowrap">
+            <Text
+                as="span"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                {...props}
+            >
+                {before}
+            </Text>
+            <Text
+                as="span"
+                flexShrink="0"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                {...props}
+            >
+                {after}
+            </Text>
+        </Flex>
+    );
+};
+export default TextWithMiddleEllipsis;

--- a/src/routes/computePlans/components/ComputePlanTr.tsx
+++ b/src/routes/computePlans/components/ComputePlanTr.tsx
@@ -14,6 +14,7 @@ import { compilePath, PATHS } from '@/paths';
 
 import Duration from '@/components/Duration';
 import { ClickableTr, rightBorderProps } from '@/components/Table';
+import TextWithMiddleEllipsis from '@/components/TextWithMiddleEllipsis';
 import Timing from '@/components/Timing';
 
 import CheckboxTd from './CheckboxTd';
@@ -148,7 +149,12 @@ const ComputePlanTr = ({
                 backgroundColor="white"
                 {...rightBorderProps}
             >
-                <Text fontSize="xs">{computePlan.name}</Text>
+                <TextWithMiddleEllipsis
+                    text={computePlan.name}
+                    charsAfterEllipsis={5}
+                    width="236px"
+                    fontSize="xs"
+                />
             </Td>
             {columns.map((column) => (
                 <ColumnTd


### PR DESCRIPTION
From @jmorel 

### Description

New component that allows ellipsis to be at N chars from the end of the string.

As for the Text component, is required a maxWidth in px to work.

TODO: apply where relevant (discussion ongoing).

### Screenshots

With ellipsis:
![Capture d’écran 2022-03-23 à 08 47 24](https://user-images.githubusercontent.com/1270900/159648951-bc9da8a5-be56-4a20-b3ad-2185df48da78.png)

Without ellipsis:
![Capture d’écran 2022-03-23 à 08 48 07](https://user-images.githubusercontent.com/1270900/159649064-4e0cb5a5-100f-4d9b-9dfd-7a82c88be651.png)
