### PR TITLE
fix: Broken unselection of CPs in comparison page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   CP duration filter is broken on refresh and for below mode
 -   Use correct login url in cypress tests
 -   Display all general columns by default in CP page
+-   Broken unselection of CPs in comparison page
 
 ## [0.32.1] - 2022-08-24
 

--- a/src/hooks/usePerfBrowser.ts
+++ b/src/hooks/usePerfBrowser.ts
@@ -239,7 +239,9 @@ const usePerfBrowser = (
         setSelectedComputePlanKeys(
             computePlans.map((computePlan) => computePlan.key)
         );
-    }, [computePlans, setSelectedComputePlanKeys]);
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [computePlans]);
 
     const seriesGroupsWithRounds = useMemo(() => {
         const groupsWithRounds = seriesGroups


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Fix CPs not being able to be unselected in CPs comparison page
