### PR TITLE
chore(docker): remove superfluous info from server headers

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -24,4 +24,5 @@ server {
     #location ~ /\.ht {
     #    deny  all;
     #}
+    server_tokens off; # restrain from giving too much info about the server
 }


### PR DESCRIPTION
## Description

Effectively, this removes the nginx version number from frontend error pages. This is only for production, it won't change anything on development

According to our security audit, we don't gain much from exposing this info, but it might give an attacker some help.

Asana task with more context: https://app.asana.com/0/1201599852028640/1202311798287732 (the parent task has a link to the full audit)

## How to test

I tried it by accessing `/assets/` on the frontend, then updating and reloading the nginx configuration and accessing the same page again to check the server version number had disappeared.

## Further considerations

A deeper question for you frontend experts is _why_ `/assets` returns a 403. I guess it's better than a directory of the folder, but I imagine a nice-looking 404 would be preferable.