### PR TITLE
fix: CP columns and favorites disappear on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Use correct login url in cypress tests
 -   Display all general columns by default in CP page
 -   Broken unselection of CPs in comparison page
+-   CP columns and favorites disappear on logout
 
 ### Removed
 

--- a/src/hooks/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState.ts
@@ -1,7 +1,6 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import useAppSelector from '@/hooks/useAppSelector';
-import useEffectOnce from '@/hooks/useEffectOnce';
 import { HasKeyT } from '@/modules/common/CommonTypes';
 
 function useLoadSave<T>(
@@ -54,9 +53,11 @@ export const useLocalStorageState = <Type>(
     const { load, save } = useLoadSave<Type>(localStorageKey, channel, migrate);
     const [state, setLocalState] = useState(() => load() ?? originalValue);
 
-    useEffectOnce(() => {
+    useEffect(() => {
         setLocalState(load() ?? originalValue);
-    });
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [channel]);
 
     const setState = useCallback(
         (state: Type) => {

--- a/src/routes/computePlans/ComputePlans.tsx
+++ b/src/routes/computePlans/ComputePlans.tsx
@@ -4,12 +4,10 @@ import { VStack, Table, Box, HStack, Flex, Button } from '@chakra-ui/react';
 import { RiDownloadLine } from 'react-icons/ri';
 
 import CustomColumnsModal from '@/features/customColumns/CustomColumnsModal';
-import { GENERAL_COLUMNS } from '@/features/customColumns/CustomColumnsUtils';
 import useCustomColumns from '@/features/customColumns/useCustomColumns';
 import useAppSelector from '@/hooks/useAppSelector';
 import useDispatchWithAutoAbort from '@/hooks/useDispatchWithAutoAbort';
 import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
-import useEffectOnce from '@/hooks/useEffectOnce';
 import useFavoriteComputePlans from '@/hooks/useFavoriteComputePlans';
 import { useLocalStorageKeyArrayState } from '@/hooks/useLocalStorageState';
 import {
@@ -154,11 +152,6 @@ const ComputePlans = (): JSX.Element => {
     );
 
     const { columns, setColumns } = useCustomColumns();
-
-    // Display general columns by default
-    useEffectOnce(() => {
-        setColumns(GENERAL_COLUMNS);
-    });
 
     const onSelectionChange = (computePlan: ComputePlanT) => () => {
         if (selectedKeys.includes(computePlan.key)) {


### PR DESCRIPTION
Signed-off-by: Hamdy Dakkak <hamdy.dakkak@owkin.com>

LINKED TO THIS [ASANA CARD](https://app.asana.com/0/1200346939311555/1202883398420791) and [ASANA CARD](https://app.asana.com/0/1200346939311555/1202937437974384)

## Description

The local storage values where not retrieved correctly.

## How to test

- Add custom columns
- Add CP as favorite
- Log out
- Log in : you should see your favorites CP and customised columns
