### PR TITLE
chore(release): 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2022-09-12
+
 ## Added
 
 -   Users management v1

--- a/charts/substra-frontend/CHANGELOG.md
+++ b/charts/substra-frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.5
+
+### Changed
+
+- Upgraded AppVersion to 0.33.0
+
 ## 1.0.4
 
 ### Changed

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -10,5 +10,5 @@ sources:
 type: application
 
 version: 1.0.4
-appVersion: 0.32.1 # should be same as in package.json
+appVersion: 0.33.0 # should be same as in package.json
 kubeVersion: ">= 1.19.0-0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "substra-frontend",
-    "version": "0.32.1",
+    "version": "0.33.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "substra-frontend",
-            "version": "0.32.1",
+            "version": "0.33.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@chakra-ui/react": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "license": "Apache-2.0",
     "private": "true",
-    "version": "0.32.1",
+    "version": "0.33.0",
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",


### PR DESCRIPTION
## [0.33.0] - 2022-09-12

## Added

-   Users management v1
-   Added license file
-   Removed references to close-source items

### Changed

-   Change Customize Columns items icon color
-   Increase page size to 30
-   CP Workflow graph: Allow a higher min zoom to show more tasks
-   CP Workflow graph: update layout for predict tasks and test tasks
-   Change Connect branding to Substra
-   Add capital letter R to reset zoom button
-   Rename Connect to Substra in code and ci files
-   Change primary color from teal to blue
-   Keep filtering/ordering setup when refreshing an asset list page
-   Display all General customize columns by default

### Fixed

-   Elements being highlighted when drag and drop Customize Columns items
-   Can edit by deleting the input number in CP duration filter
-   CP duration filter is broken on refresh and for below mode
-   Use correct login url in cypress tests
-   Display all general columns by default in CP page
-   Broken unselection of CPs in comparison page
-   CP columns and favorites disappear on logout

### Removed

-   Model category
