### PR TITLE
feat: add Cypress tests for CP Workflow and Performances page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+-   Cypress tests for compute plan pages Workflow and Performances
+
 ## [0.33.0] - 2022-09-12
 
 ## Added

--- a/e2e-tests/cypress/integration/computePlans.spec.js
+++ b/e2e-tests/cypress/integration/computePlans.spec.js
@@ -13,4 +13,21 @@ describe('Compute plans page', () => {
         cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
         cy.url().should('match', /compute_plans\/.{36}\/tasks/);
     });
+
+    it('navigates to the Workflow page', () => {
+        cy.get('[data-cy=Workflow-tab]').click({ force: true });
+        cy.url().should('match', /compute_plans\/.{36}\/workflow/);
+        cy.get('[data-cy=workflow-graph]').should('exist');
+    });
+
+    it('navigates back to the Detail page', () => {
+        cy.get('[data-cy=Details-tab]').click({ force: true });
+        cy.url().should('match', /compute_plans\/.{36}\/tasks/);
+    });
+
+    it('navigates to the Performance page', () => {
+        cy.get('[data-cy=Performances-tab]').click({ force: true });
+        cy.url().should('match', /compute_plans\/.{36}\/chart/);
+        cy.get('[data-cy=cp-chart]').should('exist');
+    });
 });

--- a/src/routes/computePlanDetails/ComputePlanChart.tsx
+++ b/src/routes/computePlanDetails/ComputePlanChart.tsx
@@ -90,6 +90,7 @@ const ComputePlanChart = (): JSX.Element => {
     return (
         <PerfBrowserContext.Provider value={context}>
             <Flex
+                data-cy="cp-chart"
                 direction="column"
                 alignItems="stretch"
                 flexGrow={1}

--- a/src/routes/computePlanDetails/components/TabsNav.tsx
+++ b/src/routes/computePlanDetails/components/TabsNav.tsx
@@ -47,6 +47,7 @@ const TabsNavItem = ({
     return (
         <Link href={href}>
             <Text
+                data-cy={`${label}-tab`}
                 as="a"
                 fontSize="sm"
                 lineHeight="5"

--- a/src/routes/computePlanDetails/components/TasksWorkflow.tsx
+++ b/src/routes/computePlanDetails/components/TasksWorkflow.tsx
@@ -143,6 +143,7 @@ const TasksWorkflow = (): JSX.Element => {
                 setPageTitle={false}
             />
             <ReactFlow
+                data-cy="workflow-graph"
                 defaultPosition={[0, 1000]} // default is set so that no node is visible before the initial fitView - which will occur when all nodes are loaded
                 fitView={true}
                 nodeTypes={nodeTypes}


### PR DESCRIPTION
Signed-off-by: Hamdy Dakkak <hamdy.dakkak@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1200346939311555/1202883398420773)

## Description
Testing the tabs Workflow and Performance with Cypress
**Important** : the cypress test are inconsistent : they fail from time to time, which make it very painful and hard to test. I investigated and this is due to an **untimely logout**. The token is blacklisted. This issue will be discussed with the team.


**NB**: With general tasks, the CP Tasks page will be modified soon : we will remove the type tabs (test, predict, train ...) and display all Tasks in one Table*.
For this reason, the test case "_CP > Tasks > any task's drawer_" will be tested when this change is done, in an other PR.

*this was discussed during the GT meeting of the last Friday 09-09-22.

