### PR TITLE
ci: handle both gcr and ghcr manifest not found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Cypress tests for compute plan pages Workflow and Performances
 
+### Fixed
+
+-   Handle both gcr and ghcr manifest not found error in release workflow ci
+
 ## [0.33.0] - 2022-09-12
 
 ## Added

--- a/ci/cilib/docker.py
+++ b/ci/cilib/docker.py
@@ -90,6 +90,6 @@ def manifest_inspect(tag) -> Union[Dict, None]:
         )
         return json.loads(o)
     except command.SubProcessException as e:
-        if "no such manifest" in e.message:
+        if "no such manifest" or "manifest unknown" in e.message:
             return None
         raise e


### PR DESCRIPTION
### Description

Before building docker image we check if a manifest with same tag already exists, if not found, then we build and push the docker image. It seems that when a manifest is not found, error returned by gcr was `no such manifest` and now on ghcr we receive the `manifest unknown` error, which was not handled.
Hopefully this will fix the release
