### PR TITLE
fix: allow to test empty workflow graph

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -6,6 +6,7 @@ type EmptyStateProps = {
     buttonOnClick?: () => void;
     buttonLabel?: string;
     icon: React.ReactNode;
+    dataCy?: string;
 };
 const EmptyState = ({
     title,
@@ -13,9 +14,10 @@ const EmptyState = ({
     buttonOnClick,
     icon,
     buttonLabel,
+    dataCy,
 }: EmptyStateProps) => {
     return (
-        <VStack spacing="5">
+        <VStack spacing="5" data-cy={dataCy}>
             <Box
                 width="20"
                 height="20"

--- a/src/routes/computePlanDetails/components/UnavailableWorkflow.tsx
+++ b/src/routes/computePlanDetails/components/UnavailableWorkflow.tsx
@@ -18,6 +18,7 @@ const UnavailableWorkflow = ({
 
     return (
         <EmptyState
+            dataCy="workflow-graph"
             icon={<RiEyeOffLine />}
             title="Unable to display this workflow"
             subtitle={subtitle}


### PR DESCRIPTION
Signed-off-by: Hamdy Dakkak <hamdy.dakkak@owkin.com>

## Description

Ci is broken because of a Cypress test. The test is related to the empty workflow graph case. This PR made sure that the empty state is taken into account during the test.

No changelog needed.