### PR TITLE
chore(release): 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2022-09-13
+
 ## Added
 
 -   Cypress tests for compute plan pages Workflow and Performances

--- a/charts/substra-frontend/CHANGELOG.md
+++ b/charts/substra-frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.6
+
+### Changed
+
+- Upgraded AppVersion to 0.34.0
+
 ## 1.0.5
 
 ### Changed

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -9,6 +9,6 @@ sources:
 
 type: application
 
-version: 1.0.4
-appVersion: 0.33.0 # should be same as in package.json
+version: 1.0.6
+appVersion: 0.34.0 # should be same as in package.json
 kubeVersion: ">= 1.19.0-0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "substra-frontend",
-    "version": "0.33.0",
+    "version": "0.34.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "substra-frontend",
-            "version": "0.33.0",
+            "version": "0.34.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@chakra-ui/react": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "license": "Apache-2.0",
     "private": "true",
-    "version": "0.33.0",
+    "version": "0.34.0",
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",


### PR DESCRIPTION
## [0.34.0] - 2022-09-13

## Added

-   Cypress tests for compute plan pages Workflow and Performances

### Fixed

-   Handle both gcr and ghcr manifest not found error in release workflow ci
