### PR TITLE
ci: keep gcr to host skaffold image build

### DIFF
--- a/automated-e2e-tests/skaffold.yaml
+++ b/automated-e2e-tests/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v2beta17
 kind: Config
 build:
     artifacts:
-        - image: &imageref gcr.io/substra/substra-frontend-tests
+        - image: &imageref substra/substra-frontend-tests
           context: ../e2e-tests
           docker:
               dockerfile: 'docker/substra-frontend-tests/Dockerfile'

--- a/automated-e2e-tests/skaffold.yaml
+++ b/automated-e2e-tests/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v2beta17
 kind: Config
 build:
     artifacts:
-        - image: &imageref ghcr.io/substra/substra-frontend-tests
+        - image: &imageref gcr.io/substra/substra-frontend-tests
           context: ../e2e-tests
           docker:
               dockerfile: 'docker/substra-frontend-tests/Dockerfile'

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v2beta16
 kind: Config
 build:
     artifacts:
-        - image: &imageref ghcr.io/substra/substra-frontend
+        - image: &imageref gcr.io/substra/substra-frontend
           context: .
           docker:
               dockerfile: docker/substra-frontend/Dockerfile

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v2beta16
 kind: Config
 build:
     artifacts:
-        - image: &imageref gcr.io/substra/substra-frontend
+        - image: &imageref substra/substra-frontend
           context: .
           docker:
               dockerfile: docker/substra-frontend/Dockerfile


### PR DESCRIPTION
### Description

Frontend skaffold configuration refers to wrong host. Images are built and push to gcr.io and this forces to handle the frontend differently in the [ci repo](https://github.com/owkin/substra-ci/blob/ea2d52719753cf2327df90e539e3ad787610058d/ci/config.py#L130). (internal link)

This PR removes this difference.

[Internal] See thread : https://owkin.slack.com/archives/C03K3JBS7H7/p1662643065715729

Companion PR:
- https://github.com/owkin/substra-ci/pull/79
