### PR TITLE
fix: Fix outdated route in withRetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fix rank tooltip on perfcards in CP performances page (#108)
+-   Fix outdated refresh route in withRetry (#112)
 
 ## [0.34.0] - 2022-09-13
 

--- a/src/libs/request.ts
+++ b/src/libs/request.ts
@@ -29,7 +29,7 @@ const withRetry =
     (url: string, config?: AxiosRequestConfig) => {
         return instanceMethod(url, config).catch((error) => {
             if (error.response && error.response.status === 401) {
-                return instance.post('/user/refresh/').then(
+                return instance.post('/me/refresh/').then(
                     () => instanceMethod(url, config),
                     () => {
                         if (!window.location.pathname.startsWith('/login')) {


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

withRetry function used in authenticatedGet was still using an outdated route for the refresh endpoint
