### PR TITLE
feat(workflow): Do not rely on task categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Display user description after role update (#117)
+-   CP workflow graph is now built independently of the task categories (#114)
 
 ## [0.35.0] - 2022-09-26
 

--- a/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
@@ -17,7 +17,7 @@ const twoTasksGraph: TaskGraphT = {
             status: TupleStatus.done,
             category: TaskCategory.train,
             inputs: [],
-            outputs: ['out_model'],
+            outputs: [{ id: 'out_model', kind: 'model' }],
         },
         {
             key: 'b',
@@ -25,7 +25,7 @@ const twoTasksGraph: TaskGraphT = {
             worker: 'pharma2',
             status: TupleStatus.failed,
             category: TaskCategory.train,
-            inputs: ['in_model'],
+            inputs: [{ id: 'in_model', kind: 'model' }],
             outputs: [],
         },
     ],
@@ -52,7 +52,7 @@ const twoTasksLayoutedGraph: LayoutedTaskGraphT = {
             ...twoTasksGraph.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
-                y: 200, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("1 task in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in second row")
+                y: 208, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("1 task in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in second row") + 8 ("uneven column top padding")
             },
         },
     ],
@@ -68,8 +68,8 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
             worker: 'pharma1',
             status: TupleStatus.done,
             category: TaskCategory.predict,
-            inputs: ['in_model'],
-            outputs: ['out_model'],
+            inputs: [{ id: 'in_model', kind: 'model' }],
+            outputs: [{ id: 'out_model', kind: 'model' }],
         },
         {
             key: 'test_a',
@@ -77,8 +77,8 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
             worker: 'pharma1',
             status: TupleStatus.done,
             category: TaskCategory.test,
-            inputs: ['in_model'],
-            outputs: [],
+            inputs: [{ id: 'in_model', kind: 'model' }],
+            outputs: [{ id: 'perf', kind: 'performance' }],
         },
     ],
     edges: [
@@ -111,7 +111,7 @@ const twoTasksPlusPredictAndTestTupleLayoutedGraph: LayoutedTaskGraphT = {
             ...twoTasksPlusPredictAndTestTupleGraph.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
-                y: 540, // 3 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("3 tasks in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in the row")
+                y: 548, // 3 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("3 tasks in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in the row") + 8 ("uneven column top padding")
             },
         },
         {
@@ -141,7 +141,10 @@ const compositeAndAggregateGraph: TaskGraphT = {
             status: TupleStatus.done,
             category: TaskCategory.composite,
             inputs: [],
-            outputs: ['out_head_model', 'out_trunk_model'],
+            outputs: [
+                { id: 'out_head_model', kind: 'model' },
+                { id: 'out_trunk_model', kind: 'model' },
+            ],
         },
         {
             key: 'aggregate_a',
@@ -149,8 +152,8 @@ const compositeAndAggregateGraph: TaskGraphT = {
             worker: 'pharma1',
             status: TupleStatus.failed,
             category: TaskCategory.aggregate,
-            inputs: ['in_models'],
-            outputs: ['out_model'],
+            inputs: [{ id: 'in_models', kind: 'model' }],
+            outputs: [{ id: 'out_model', kind: 'model' }],
         },
         {
             key: 'composite_b',
@@ -158,7 +161,10 @@ const compositeAndAggregateGraph: TaskGraphT = {
             worker: 'pharma1',
             status: TupleStatus.done,
             category: TaskCategory.composite,
-            inputs: ['in_head_model', 'in_trunk_model'],
+            inputs: [
+                { id: 'in_head_model', kind: 'model' },
+                { id: 'in_trunk_model', kind: 'model' },
+            ],
             outputs: [],
         },
     ],
@@ -197,7 +203,7 @@ const compositeAndAggregateLAyoutedGraph: LayoutedTaskGraphT = {
             ...compositeAndAggregateGraph.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
-                y: 52, // // 0 ("first task in the row") + AGGREGATE_TASK_TOP_PADDING
+                y: 8, // // 0 ("first task in the row") + 8 ("uneven column top padding")
             },
         },
         {

--- a/src/modules/cpWorkflow/CPWorkflowLayout.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.ts
@@ -20,6 +20,7 @@ type TaskInCellT = {
 type GridCellT = {
     tasks: TaskInCellT[];
     x: number;
+    y: number;
 };
 
 type GridRowT = {
@@ -46,9 +47,10 @@ function initEmptyGrid(workerNamesInYOrder: string[], maxRank: number) {
     for (const workerName of workerNamesInYOrder) {
         grid.rows[workerName] = {
             maxNbTasksInACell: 0,
-            cells: Array.from({ length: maxRank + 1 }, () => ({
+            cells: Array.from({ length: maxRank + 1 }, (_, index) => ({
                 tasks: [],
                 x: 0,
+                y: (index % 2) * 8, // Add a small vertical padding every 2 column to help avoiding some edges to overlap
             })),
             y: 0,
             height: 0,
@@ -312,7 +314,7 @@ export function computeLayout(graph: TaskGraphT): LayoutedTaskGraphT {
             ...task,
             position: {
                 x: cell.x + (taskInCell as TaskInCellT).relativeXInCell,
-                y: row.y + (taskInCell as TaskInCellT).relativeYInCell,
+                y: row.y + cell.y + (taskInCell as TaskInCellT).relativeYInCell,
             },
         };
     });

--- a/src/modules/cpWorkflow/CPWorkflowLayout.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.ts
@@ -3,14 +3,12 @@ import {
     TaskGraphT,
     TaskT,
 } from '@/modules/cpWorkflow/CPWorkflowTypes';
-import { TaskCategory } from '@/modules/tasks/TuplesTypes';
 
 export const NODE_WIDTH = 250;
 export const NODE_HEIGHT = 119;
 
 const NODE_BOTTOM_MARGIN = 51; // Add margin to the node height avoid stacking nodes
 const ROW_BOTTOM_MARGIN = 30;
-const AGGREGATE_TASK_TOP_PADDING = 52;
 const CELL_WIDTH = NODE_WIDTH + 150;
 
 type TaskInCellT = {
@@ -167,12 +165,6 @@ function computeTasksRelativePositionInCell(
             taskRankInSecondaryBranch[task.taskRef.key];
         if (rankInSecondaryBranch) {
             task.relativeXInCell += rankInSecondaryBranch * 30;
-        }
-
-        if (task.taskRef.category === TaskCategory.aggregate) {
-            // Aggregatetuple are drawn with a little shifting on the y axis
-            // to avoid they are drawn on top of composite-to-composite edges of the same worker
-            task.relativeYInCell += AGGREGATE_TASK_TOP_PADDING;
         }
     }
 

--- a/src/modules/cpWorkflow/CPWorkflowLayout.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.ts
@@ -10,10 +10,8 @@ export const NODE_HEIGHT = 119;
 
 const NODE_BOTTOM_MARGIN = 51; // Add margin to the node height avoid stacking nodes
 const ROW_BOTTOM_MARGIN = 30;
-const PREDICT_TASK_LEFT_PADDING = 30;
-const TEST_TASK_LEFT_PADDING = 60;
 const AGGREGATE_TASK_TOP_PADDING = 52;
-const CELL_WIDTH = NODE_WIDTH + TEST_TASK_LEFT_PADDING + 90;
+const CELL_WIDTH = NODE_WIDTH + 150;
 
 type TaskInCellT = {
     taskRef: TaskT;
@@ -61,22 +59,26 @@ function initEmptyGrid(workerNamesInYOrder: string[], maxRank: number) {
     return grid;
 }
 
-function getColumnIndex(task: TaskT) {
-    let correctedRank: number;
-    if (task.category === TaskCategory.predict) {
-        correctedRank = task.rank - 1;
-    } else if (task.category === TaskCategory.test) {
-        correctedRank = task.rank - 2;
-    } else {
-        correctedRank = task.rank;
-    }
+function getColumnIndex(
+    task: TaskT,
+    taskRankInSecondaryBranch: { [task_key: string]: number }
+) {
+    const correctedRank: number =
+        task.rank - (taskRankInSecondaryBranch[task.key] ?? 0);
     return Math.max(0, correctedRank);
 }
 
-function addTasksToGrid(grid: GridT, tasks: TaskT[]) {
+function addTasksToGrid(
+    grid: GridT,
+    tasks: TaskT[],
+    taskRankInSecondaryBranch: { [task_key: string]: number }
+) {
     // Assign tasks to their cell
     for (const task of tasks) {
-        const cell = grid.rows[task.worker].cells[getColumnIndex(task)];
+        const cell =
+            grid.rows[task.worker].cells[
+                getColumnIndex(task, taskRankInSecondaryBranch)
+            ];
         cell.tasks.push({
             taskRef: task,
             relativeXInCell: 0,
@@ -121,21 +123,10 @@ function computeCellsX(rows: RowsT) {
     }
 }
 
-function orderTasksInEachCell(rows: RowsT, graph: TaskGraphT) {
-    const taskKeyToTaskMap: { [task_key: string]: TaskT } = {};
-    for (const task of graph.tasks) {
-        taskKeyToTaskMap[task.key] = task;
-    }
-
-    const taskKeyToParentTasksMap: { [task_key: string]: TaskT[] } = {};
-    for (const edge of graph.edges) {
-        const targetTaskKey = edge.target_task_key;
-        const parentTask = taskKeyToTaskMap[edge.source_task_key];
-
-        const parentTasks = taskKeyToParentTasksMap[targetTaskKey] ?? [];
-        taskKeyToParentTasksMap[targetTaskKey] = [...parentTasks, parentTask];
-    }
-
+function orderTasksInEachCell(
+    rows: RowsT,
+    taskKeyToParentTasksMap: { [task_key: string]: TaskT[] }
+) {
     for (const row of Object.values(rows)) {
         for (const cell of row.cells) {
             cell.tasks.sort((firstTask, secondTask) => {
@@ -160,7 +151,10 @@ function orderTasksInEachCell(rows: RowsT, graph: TaskGraphT) {
     }
 }
 
-function computeTasksRelativePositionInCell(rows: RowsT) {
+function computeTasksRelativePositionInCell(
+    rows: RowsT,
+    taskRankInSecondaryBranch: { [task_key: string]: number }
+) {
     function computeTaskRelativePositionInCell(
         task: TaskInCellT,
         cell: GridCellT
@@ -169,15 +163,12 @@ function computeTasksRelativePositionInCell(rows: RowsT) {
         task.relativeYInCell =
             cell.tasks.indexOf(task) * (NODE_HEIGHT + NODE_BOTTOM_MARGIN);
 
-        if (task.taskRef.category === TaskCategory.test) {
-            // Testtuples are drawn with a little shifting on the x axis
-            // to symbolize they are executed after the other tasks of the same rank
-            task.relativeXInCell += TEST_TASK_LEFT_PADDING;
+        const rankInSecondaryBranch =
+            taskRankInSecondaryBranch[task.taskRef.key];
+        if (rankInSecondaryBranch) {
+            task.relativeXInCell += rankInSecondaryBranch * 30;
         }
-        if (task.taskRef.category === TaskCategory.predict) {
-            // Same as Testtuples
-            task.relativeXInCell += PREDICT_TASK_LEFT_PADDING;
-        }
+
         if (task.taskRef.category === TaskCategory.aggregate) {
             // Aggregatetuple are drawn with a little shifting on the y axis
             // to avoid they are drawn on top of composite-to-composite edges of the same worker
@@ -194,27 +185,133 @@ function computeTasksRelativePositionInCell(rows: RowsT) {
     }
 }
 
+function findSecondaryBranches(
+    graph: TaskGraphT,
+    taskKeyToParentTasksMap: { [task_key: string]: TaskT[] }
+): { [task_key: string]: number } {
+    function producesOnlyPerformances(task: TaskT) {
+        const outputKinds = new Set(
+            Object.values(task.outputs).map((output) => output.kind)
+        );
+        return (
+            outputKinds.size === 1 &&
+            outputKinds.values().next().value === 'performance'
+        );
+    }
+
+    function computeNbOfChildren(graph: TaskGraphT, task: TaskT) {
+        return graph.edges.filter((edge) => edge.source_task_key === task.key)
+            .length;
+    }
+
+    // Recusrsive function to walk through parent tasks as long as it is a linear chain to find the secondary branch
+    function recFindSecondaryBranch(
+        task: TaskT,
+        graph: TaskGraphT,
+        taskKeyToParentTasksMap: { [task_key: string]: TaskT[] },
+        tasksInSecondaryBranches: { [task_key: string]: number }
+    ) {
+        const parents: TaskT[] = Object.values(
+            taskKeyToParentTasksMap[task.key]
+        );
+        if (parents.length === 0) {
+            // The secondary branch is not connected to the rest of the workflow
+            // Let us not tune the layout for this specific case
+            return null;
+        } else if (parents.length === 1) {
+            const parent = parents[0];
+
+            if (computeNbOfChildren(graph, parent) === 1) {
+                // The parent has no other child than this task, it is part of the secondary branch
+                // We recursively continue to walk through its parents
+                const parentRankInSecondaryBranch = recFindSecondaryBranch(
+                    parent,
+                    graph,
+                    taskKeyToParentTasksMap,
+                    tasksInSecondaryBranches
+                );
+                if (parentRankInSecondaryBranch !== null) {
+                    tasksInSecondaryBranches[task.key] =
+                        parentRankInSecondaryBranch + 1;
+                    return tasksInSecondaryBranches[task.key];
+                } else {
+                    return null;
+                }
+            } else {
+                // The parent has other children so it is the point where the secondary branch starts
+                // The task is first in the secondary branch
+                tasksInSecondaryBranches[task.key] = 1;
+                return tasksInSecondaryBranches[task.key];
+            }
+        } else {
+            // The task has several parents so it is not in the secondary branch
+            return 0;
+        }
+    }
+
+    const taskRanksInSecondaryBranch: { [task_key: string]: number } = {};
+
+    const endOfSecondaryBranches = graph.tasks.filter((task) => {
+        return (
+            computeNbOfChildren(graph, task) === 0 &&
+            producesOnlyPerformances(task)
+        );
+    });
+
+    for (const task of endOfSecondaryBranches) {
+        recFindSecondaryBranch(
+            task,
+            graph,
+            taskKeyToParentTasksMap,
+            taskRanksInSecondaryBranch
+        );
+    }
+
+    return taskRanksInSecondaryBranch;
+}
+
 export function computeLayout(graph: TaskGraphT): LayoutedTaskGraphT {
     const workerNames = [...new Set(graph.tasks.map((task) => task.worker))];
     workerNames.sort();
 
+    const taskKeyToTaskMap: { [task_key: string]: TaskT } = {};
+    for (const task of graph.tasks) {
+        taskKeyToTaskMap[task.key] = task;
+    }
+
+    const taskKeyToParentTasksMap: { [task_key: string]: TaskT[] } = {};
+    for (const edge of graph.edges) {
+        const targetTaskKey = edge.target_task_key;
+        const parentTask = taskKeyToTaskMap[edge.source_task_key];
+
+        const parentTasks = taskKeyToParentTasksMap[targetTaskKey] ?? [];
+        taskKeyToParentTasksMap[targetTaskKey] = [...parentTasks, parentTask];
+    }
+
+    const taskRankInSecondaryBranch = findSecondaryBranches(
+        graph,
+        taskKeyToParentTasksMap
+    );
+
     const maxRank = Math.max(
-        ...graph.tasks.map((task) => getColumnIndex(task))
+        ...graph.tasks.map((task) =>
+            getColumnIndex(task, taskRankInSecondaryBranch)
+        )
     );
 
     const grid: GridT = initEmptyGrid(workerNames, maxRank);
-    addTasksToGrid(grid, graph.tasks);
+    addTasksToGrid(grid, graph.tasks, taskRankInSecondaryBranch);
 
     computeRowsHeight(grid.rows);
     computeRowsY(grid);
     computeCellsX(grid.rows);
 
-    orderTasksInEachCell(grid.rows, graph);
-    computeTasksRelativePositionInCell(grid.rows);
+    orderTasksInEachCell(grid.rows, taskKeyToParentTasksMap);
+    computeTasksRelativePositionInCell(grid.rows, taskRankInSecondaryBranch);
 
     const positionedTasks = graph.tasks.map((task) => {
         const row = grid.rows[task.worker];
-        const cell = row.cells[getColumnIndex(task)];
+        const cell = row.cells[getColumnIndex(task, taskRankInSecondaryBranch)];
         const taskInCell = cell.tasks.find((taskInCell) => {
             return taskInCell.taskRef.key === task.key;
         });

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -5,14 +5,19 @@ type PositionT = {
     y: number;
 };
 
+type PlugT = {
+    id: 'string';
+    kind: 'string';
+};
+
 export type TaskT = {
     key: string;
     rank: number;
     worker: string;
     status: TupleStatus;
     category: TaskCategory;
-    inputs: string[];
-    outputs: string[];
+    inputs: PlugT[];
+    outputs: PlugT[];
 };
 
 export type PositionedTaskT = TaskT & {

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -6,8 +6,8 @@ type PositionT = {
 };
 
 type PlugT = {
-    id: 'string';
-    kind: 'string';
+    id: string;
+    kind: string;
 };
 
 export type TaskT = {

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -1,4 +1,4 @@
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskCategory, TupleStatus } from '@/modules/tasks/TuplesTypes';
 
 type PositionT = {
     x: number;
@@ -15,6 +15,7 @@ export type TaskT = {
     rank: number;
     worker: string;
     status: TupleStatus;
+    category: TaskCategory;
     inputs: PlugT[];
     outputs: PlugT[];
 };

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -1,4 +1,4 @@
-import { TaskCategory, TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TupleStatus } from '@/modules/tasks/TuplesTypes';
 
 type PositionT = {
     x: number;
@@ -15,7 +15,6 @@ export type TaskT = {
     rank: number;
     worker: string;
     status: TupleStatus;
-    category: TaskCategory;
     inputs: PlugT[];
     outputs: PlugT[];
 };

--- a/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
+++ b/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
@@ -9,7 +9,6 @@ import {
     NODE_BORDER_COLOR,
     NODE_LABEL_COLOR,
 } from '@/modules/cpWorkflow/CPWorkflowUtils';
-import { CATEGORY_LABEL } from '@/modules/tasks/TasksUtils';
 
 type TaskNodeProps = {
     data: PositionedTaskT;
@@ -23,11 +22,11 @@ const TaskNode = ({ data }: TaskNodeProps) => {
         <>
             {/*Handles*/}
             {data.inputs.map((value, index) => (
-                <Box key={value}>
+                <Box key={value.id}>
                     <Handle
                         type="target"
                         position={Position.Left}
-                        id={value}
+                        id={value.id}
                         style={{
                             borderRadius: handleRadius,
                             top: handleTopMargin + handleElementMargin * index,
@@ -41,11 +40,11 @@ const TaskNode = ({ data }: TaskNodeProps) => {
                 </Box>
             ))}
             {data.outputs.map((value, index) => (
-                <Box key={value}>
+                <Box key={value.id}>
                     <Handle
                         type="source"
                         position={Position.Right}
-                        id={value}
+                        id={value.id}
                         style={{
                             borderRadius: handleRadius,
                             top: handleTopMargin + handleElementMargin * index,
@@ -66,9 +65,7 @@ const TaskNode = ({ data }: TaskNodeProps) => {
                     backgroundColor={NODE_BORDER_COLOR[data.status]}
                     color="white"
                 >
-                    <Text fontWeight="bold">{`${
-                        CATEGORY_LABEL[data.category]
-                    } task`}</Text>
+                    <Text fontWeight="bold">_</Text>
                     <Text
                         pos="absolute"
                         top="5px"
@@ -94,15 +91,15 @@ const TaskNode = ({ data }: TaskNodeProps) => {
                     <Flex display="flex" gap="6px">
                         <Box flex="50%" textAlign="left">
                             {data.inputs.map((value) => (
-                                <Text margin="0 auto 0 3px" key={value}>
-                                    {value}
+                                <Text margin="0 auto 0 3px" key={value.id}>
+                                    {value.id}
                                 </Text>
                             ))}
                         </Box>
                         <Box flex="50%" textAlign="right">
                             {data.outputs.map((value) => (
-                                <Text margin="0 3px 0 auto" key={value}>
-                                    {value}
+                                <Text margin="0 3px 0 auto" key={value.id}>
+                                    {value.id}
                                 </Text>
                             ))}
                         </Box>


### PR DESCRIPTION
[ASANA TASK](https://app.asana.com/0/1200346939311555/1203023779458048/f)

This is a preparatory work to removing the task categories.
- Now the layout algorithm does not rely on task categories. Instead some chains of tasks are identified as "secondary branches" to be stacked vertically (like it was before for the predict and the test tasks).
- Also, the category is not displayed anymore in the task header. (In a later PR we should modify the design, the header is not really useful anymore)

This relies on a backend change: new information is needed in the response to be able to identify those secondary branches (see the code for details)
Companion PRs:
- [backend](https://github.com/Substra/substra-backend/pull/477) 
- ~~substra~~: Not impacted
