### PR TITLE
feat: make container build error logs accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   CP workflow graph is now built independently of the task categories (#114)
 -   Empty task inputs make drawer crash (#120)
 
+### Changed
+
+-   Container build error logs are now accessible
+
 ## [0.35.0] - 2022-09-26
 
 ## Added

--- a/src/routes/tasks/components/ErrorAlert.tsx
+++ b/src/routes/tasks/components/ErrorAlert.tsx
@@ -57,25 +57,52 @@ const ErrorAlert = ({ task }: { task: AnyTupleT }): JSX.Element | null => {
             />
         );
     } else if (task.error_type === ErrorT.build) {
-        return (
-            <ErrorAlertBase
-                title="Build error"
-                description={
-                    <>
-                        An error occurred when building the container for the
-                        task execution. Please check your algorithm archive or
-                        contact{' '}
-                        <Link
-                            href="https://lfaifoundation.slack.com/#substra-help"
-                            isExternal
-                        >
-                            substra-help Slack channel
-                        </Link>{' '}
-                        to get access to logs.
-                    </>
-                }
-            />
-        );
+        if (!task.logs_permission || !hasPermission(task.logs_permission)) {
+            return (
+                <ErrorAlertBase
+                    title="Build error"
+                    description={
+                        <>
+                            An error occurred when building the container for
+                            the task execution. Please check your algorithm
+                            archive or contact{' '}
+                            <Link
+                                href="https://lfaifoundation.slack.com/#substra-help"
+                                isExternal
+                            >
+                                substra-help Slack channel
+                            </Link>{' '}
+                            to get access to logs.
+                        </>
+                    }
+                />
+            );
+        } else {
+            return (
+                <>
+                    <ErrorAlertBase
+                        title="Build error"
+                        description={
+                            <>
+                                <Text>
+                                    An error occurred when building the
+                                    container for the task execution.{' '}
+                                    <Button
+                                        variant="link"
+                                        size="xs"
+                                        color="red.900"
+                                        onClick={onOpen}
+                                    >
+                                        See complete logs
+                                    </Button>
+                                </Text>
+                            </>
+                        }
+                    />
+                    <LogsModal isOpen={isOpen} onClose={onClose} task={task} />
+                </>
+            );
+        }
     } else {
         // task.error_type === ErrorT.execution
         if (!task.logs_permission || !hasPermission(task.logs_permission)) {


### PR DESCRIPTION
Companion PRs:
- https://github.com/Substra/substra-backend/pull/483 (main PR)
- https://github.com/Substra/orchestrator/pull/38
- https://github.com/Substra/substra/pull/295
- https://github.com/Substra/substra-tests/pull/218
- https://github.com/Substra/substra-frontend/pull/116 (this PR)
- https://github.com/Substra/substra-documentation/pull/184

--- 

Previously, only execution errors had logs. Now, build errors have logs too.