### PR TITLE
fix: show hidden user description on user update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Display user description after role update (#117)
+
 ## [0.35.0] - 2022-09-26
 
 ## Added

--- a/src/routes/users/components/UpdateUserForm.tsx
+++ b/src/routes/users/components/UpdateUserForm.tsx
@@ -75,7 +75,9 @@ const UpdateUserForm = ({
 
             toast({
                 title: `User updated`,
-                description: `${user.username} was successfully updated!`,
+                descriptionComponent: () => (
+                    <Text>{user.username} was successfully updated!</Text>
+                ),
                 status: 'success',
                 isClosable: true,
             });


### PR DESCRIPTION
Signed-off-by: Hamdy Dakkak <hamdy.dakkak@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1200346939311555/1203045553360637/f)

## Description

When updating a user role, we do not see the description informations on the toast (name of the user mainly).
## How to test


## Screenshots
<img width="411" alt="Capture d’écran 2022-09-27 à 10 33 19" src="https://user-images.githubusercontent.com/44287876/192491710-1b166bb8-5291-4657-8283-2492714f7e62.png">
