### PR TITLE
fix(workflow): Graph is built from info from db (not hardcoded in/out)

### DIFF
--- a/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
@@ -1,5 +1,5 @@
 import { computeLayout } from '@/modules/cpWorkflow/CPWorkflowLayout';
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 import { LayoutedTaskGraphT, TaskGraphT } from './CPWorkflowTypes';
 
@@ -22,7 +22,7 @@ const twoTasksGraph: TaskGraphT = {
             key: 'a',
             rank: 0,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs_specs: [],
             outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
         },
@@ -30,7 +30,7 @@ const twoTasksGraph: TaskGraphT = {
             key: 'b',
             rank: 1,
             worker: 'pharma2',
-            status: TupleStatus.failed,
+            status: TaskStatus.failed,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
             outputs_specs: [],
         },
@@ -82,7 +82,7 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
             key: 'predict_a',
             rank: 1,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
             outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
         },
@@ -90,7 +90,7 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
             key: 'test_a',
             rank: 2,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
             outputs_specs: [{ identifier: 'perf', kind: 'ASSET_PERFORMANCE' }],
         },
@@ -157,7 +157,7 @@ const singleChainGraphWithBypassingEdge: TaskGraphT = {
             key: 'task_a',
             rank: 0,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs_specs: [],
             outputs_specs: [
                 { identifier: 'out_model_a', kind: 'ASSET_MODEL' },
@@ -168,7 +168,7 @@ const singleChainGraphWithBypassingEdge: TaskGraphT = {
             key: 'task_b',
             rank: 1,
             worker: 'pharma1',
-            status: TupleStatus.failed,
+            status: TaskStatus.failed,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
             outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
         },
@@ -176,7 +176,7 @@ const singleChainGraphWithBypassingEdge: TaskGraphT = {
             key: 'task_c',
             rank: 2,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs_specs: [{ identifier: 'in_models', kind: 'ASSET_MODEL' }],
             outputs_specs: [],
         },

--- a/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
@@ -146,89 +146,88 @@ const twoTasksPlusPredictAndTestTupleLayoutedGraph: LayoutedTaskGraphT = {
     edges: twoTasksPlusPredictAndTestTupleGraph.edges,
 };
 
-const compositeAndAggregateGraph: TaskGraphT = {
+const singleChainGraphWithBypassingEdge: TaskGraphT = {
     //............................
     // pharma1
-    //         composite_a -> aggregate_a -> composite_b
+    //         task_a -> task_b ----> task_c
+    //             |              |
+    //             +--------------+
     tasks: [
         {
-            key: 'composite_a',
+            key: 'task_a',
             rank: 0,
             worker: 'pharma1',
             status: TupleStatus.done,
             inputs_specs: [],
             outputs_specs: [
-                { identifier: 'out_head_model', kind: 'ASSET_MODEL' },
-                { identifier: 'out_trunk_model', kind: 'ASSET_MODEL' },
+                { identifier: 'out_model_a', kind: 'ASSET_MODEL' },
+                { identifier: 'out_model_b', kind: 'ASSET_MODEL' },
             ],
         },
         {
-            key: 'aggregate_a',
+            key: 'task_b',
             rank: 1,
             worker: 'pharma1',
             status: TupleStatus.failed,
-            inputs_specs: [{ identifier: 'in_models', kind: 'ASSET_MODEL' }],
+            inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
             outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
         },
         {
-            key: 'composite_b',
+            key: 'task_c',
             rank: 2,
             worker: 'pharma1',
             status: TupleStatus.done,
-            inputs_specs: [
-                { identifier: 'in_head_model', kind: 'ASSET_MODEL' },
-                { identifier: 'in_trunk_model', kind: 'ASSET_MODEL' },
-            ],
+            inputs_specs: [{ identifier: 'in_models', kind: 'ASSET_MODEL' }],
             outputs_specs: [],
         },
     ],
     edges: [
         {
-            source_task_key: 'composite_a',
-            source_output_identifier: 'out_head_model',
-            target_task_key: 'composite_b',
-            target_input_identifier: 'in_head_model',
+            source_task_key: 'task_a',
+            source_output_identifier: 'out_model_a',
+            target_task_key: 'task_b',
+            target_input_identifier: 'in_model',
         },
         {
-            source_task_key: 'composite_a',
-            source_output_identifier: 'out_trunk_model',
-            target_task_key: 'aggregate_a',
+            source_task_key: 'task_a',
+            source_output_identifier: 'out_model_b',
+            target_task_key: 'task_c',
             target_input_identifier: 'in_models',
         },
         {
-            source_task_key: 'aggregate_a',
+            source_task_key: 'task_b',
             source_output_identifier: 'out_model',
-            target_task_key: 'composite_b',
-            target_input_identifier: 'in_trunk_model',
+            target_task_key: 'task_c',
+            target_input_identifier: 'in_model',
         },
     ],
 };
 
-const compositeAndAggregateLAyoutedGraph: LayoutedTaskGraphT = {
+const singleChainLayoutedGraphWithBypassingEdge: LayoutedTaskGraphT = {
     tasks: [
         {
-            ...compositeAndAggregateGraph.tasks[0],
+            ...singleChainGraphWithBypassingEdge.tasks[0],
             position: {
                 x: 0, // 0 ("in first column")
                 y: 0, // 0 ("first task in the row")
             },
         },
         {
-            ...compositeAndAggregateGraph.tasks[1],
+            ...singleChainGraphWithBypassingEdge.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
                 y: 8, // // 0 ("first task in the row") + 8 ("uneven column top padding")
             },
         },
         {
-            ...compositeAndAggregateGraph.tasks[2],
+            ...singleChainGraphWithBypassingEdge.tasks[2],
             position: {
                 x: 800, // 2 * CELL_WIDTH ("task in third column")
                 y: 0, // 0 ("first task in the row")
             },
         },
     ],
-    edges: compositeAndAggregateGraph.edges,
+    edges: singleChainGraphWithBypassingEdge.edges,
 };
 
 test('computeLayout', () => {
@@ -237,7 +236,7 @@ test('computeLayout', () => {
     expect(computeLayout(twoTasksPlusPredictAndTestTupleGraph)).toStrictEqual(
         twoTasksPlusPredictAndTestTupleLayoutedGraph
     );
-    expect(computeLayout(compositeAndAggregateGraph)).toStrictEqual(
-        compositeAndAggregateLAyoutedGraph
+    expect(computeLayout(singleChainGraphWithBypassingEdge)).toStrictEqual(
+        singleChainLayoutedGraphWithBypassingEdge
     );
 });

--- a/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
@@ -38,9 +38,9 @@ const twoTasksGraph: TaskGraphT = {
     edges: [
         {
             source_task_key: 'a',
-            source_output_name: 'out_model',
+            source_output_identifier: 'out_model',
             target_task_key: 'b',
-            target_input_name: 'in_model',
+            target_input_identifier: 'in_model',
         },
     ],
 };
@@ -99,15 +99,15 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
         ...twoTasksGraph.edges,
         {
             source_task_key: 'a',
-            source_output_name: 'out_model',
+            source_output_identifier: 'out_model',
             target_task_key: 'predict_a',
-            target_input_name: 'in_model',
+            target_input_identifier: 'in_model',
         },
         {
             source_task_key: 'predict_a',
-            source_output_name: 'out_model',
+            source_output_identifier: 'out_model',
             target_task_key: 'test_a',
-            target_input_name: 'in_model',
+            target_input_identifier: 'in_model',
         },
     ],
 };
@@ -185,21 +185,21 @@ const compositeAndAggregateGraph: TaskGraphT = {
     edges: [
         {
             source_task_key: 'composite_a',
-            source_output_name: 'out_head_model',
+            source_output_identifier: 'out_head_model',
             target_task_key: 'composite_b',
-            target_input_name: 'in_head_model',
+            target_input_identifier: 'in_head_model',
         },
         {
             source_task_key: 'composite_a',
-            source_output_name: 'out_trunk_model',
+            source_output_identifier: 'out_trunk_model',
             target_task_key: 'aggregate_a',
-            target_input_name: 'in_models',
+            target_input_identifier: 'in_models',
         },
         {
             source_task_key: 'aggregate_a',
-            source_output_name: 'out_model',
+            source_output_identifier: 'out_model',
             target_task_key: 'composite_b',
-            target_input_name: 'in_trunk_model',
+            target_input_identifier: 'in_trunk_model',
         },
     ],
 };

--- a/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
@@ -1,5 +1,5 @@
 import { computeLayout } from '@/modules/cpWorkflow/CPWorkflowLayout';
-import { TaskStatus } from '@/modules/tasks/TasksTypes';
+import { TaskCategory, TupleStatus } from '@/modules/tasks/TuplesTypes';
 
 import { LayoutedTaskGraphT, TaskGraphT } from './CPWorkflowTypes';
 
@@ -14,7 +14,7 @@ const twoTasksGraph: TaskGraphT = {
             key: 'a',
             rank: 0,
             worker: 'pharma1',
-            status: TaskStatus.done,
+            status: TupleStatus.done,
             inputs: [],
             outputs: [{ id: 'out_model', kind: 'model' }],
         },
@@ -22,7 +22,7 @@ const twoTasksGraph: TaskGraphT = {
             key: 'b',
             rank: 1,
             worker: 'pharma2',
-            status: TaskStatus.failed,
+            status: TupleStatus.failed,
             inputs: [{ id: 'in_model', kind: 'model' }],
             outputs: [],
         },
@@ -57,14 +57,14 @@ const twoTasksLayoutedGraph: LayoutedTaskGraphT = {
     edges: twoTasksGraph.edges,
 };
 
-const twoTasksPlusPredictAndTestTaskGraph: TaskGraphT = {
+const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
     tasks: [
         ...twoTasksGraph.tasks,
         {
             key: 'predict_a',
             rank: 1,
             worker: 'pharma1',
-            status: TaskStatus.done,
+            status: TupleStatus.done,
             inputs: [{ id: 'in_model', kind: 'model' }],
             outputs: [{ id: 'out_model', kind: 'model' }],
         },
@@ -72,7 +72,7 @@ const twoTasksPlusPredictAndTestTaskGraph: TaskGraphT = {
             key: 'test_a',
             rank: 2,
             worker: 'pharma1',
-            status: TaskStatus.done,
+            status: TupleStatus.done,
             inputs: [{ id: 'in_model', kind: 'model' }],
             outputs: [{ id: 'perf', kind: 'performance' }],
         },
@@ -94,38 +94,38 @@ const twoTasksPlusPredictAndTestTaskGraph: TaskGraphT = {
     ],
 };
 
-const twoTasksPlusPredictAndTestTaskLayoutedGraph: LayoutedTaskGraphT = {
+const twoTasksPlusPredictAndTestTupleLayoutedGraph: LayoutedTaskGraphT = {
     tasks: [
         {
-            ...twoTasksPlusPredictAndTestTaskGraph.tasks[0],
+            ...twoTasksPlusPredictAndTestTupleGraph.tasks[0],
             position: {
                 x: 0, // 0 ("in first column")
                 y: 0, // 0 ("first task in the row")
             },
         },
         {
-            ...twoTasksPlusPredictAndTestTaskGraph.tasks[1],
+            ...twoTasksPlusPredictAndTestTupleGraph.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
                 y: 548, // 3 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("3 tasks in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in the row") + 8 ("uneven column top padding")
             },
         },
         {
-            ...twoTasksPlusPredictAndTestTaskGraph.tasks[2],
+            ...twoTasksPlusPredictAndTestTupleGraph.tasks[2],
             position: {
                 x: 30, // 0 ("in first column") + PREDICT_TASK_LEFT_PADDING
                 y: 170, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("second task in the row")
             },
         },
         {
-            ...twoTasksPlusPredictAndTestTaskGraph.tasks[3],
+            ...twoTasksPlusPredictAndTestTupleGraph.tasks[3],
             position: {
                 x: 60, // 0 ("in first column") + PREDICT_TASK_LEFT_PADDING
                 y: 340, // 2 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("thirsd task in the row")
             },
         },
     ],
-    edges: twoTasksPlusPredictAndTestTaskGraph.edges,
+    edges: twoTasksPlusPredictAndTestTupleGraph.edges,
 };
 
 const compositeAndAggregateGraph: TaskGraphT = {
@@ -134,7 +134,7 @@ const compositeAndAggregateGraph: TaskGraphT = {
             key: 'composite_a',
             rank: 0,
             worker: 'pharma1',
-            status: TaskStatus.done,
+            status: TupleStatus.done,
             inputs: [],
             outputs: [
                 { id: 'out_head_model', kind: 'model' },
@@ -145,7 +145,7 @@ const compositeAndAggregateGraph: TaskGraphT = {
             key: 'aggregate_a',
             rank: 1,
             worker: 'pharma1',
-            status: TaskStatus.failed,
+            status: TupleStatus.failed,
             inputs: [{ id: 'in_models', kind: 'model' }],
             outputs: [{ id: 'out_model', kind: 'model' }],
         },
@@ -153,7 +153,7 @@ const compositeAndAggregateGraph: TaskGraphT = {
             key: 'composite_b',
             rank: 2,
             worker: 'pharma1',
-            status: TaskStatus.done,
+            status: TupleStatus.done,
             inputs: [
                 { id: 'in_head_model', kind: 'model' },
                 { id: 'in_trunk_model', kind: 'model' },
@@ -213,8 +213,8 @@ const compositeAndAggregateLAyoutedGraph: LayoutedTaskGraphT = {
 test('computeLayout', () => {
     expect(computeLayout(emptyGraph)).toStrictEqual(emptyGraph);
     expect(computeLayout(twoTasksGraph)).toStrictEqual(twoTasksLayoutedGraph);
-    expect(computeLayout(twoTasksPlusPredictAndTestTaskGraph)).toStrictEqual(
-        twoTasksPlusPredictAndTestTaskLayoutedGraph
+    expect(computeLayout(twoTasksPlusPredictAndTestTupleGraph)).toStrictEqual(
+        twoTasksPlusPredictAndTestTupleLayoutedGraph
     );
     expect(computeLayout(compositeAndAggregateGraph)).toStrictEqual(
         compositeAndAggregateLAyoutedGraph

--- a/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
@@ -1,5 +1,5 @@
 import { computeLayout } from '@/modules/cpWorkflow/CPWorkflowLayout';
-import { TaskCategory, TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TupleStatus } from '@/modules/tasks/TuplesTypes';
 
 import { LayoutedTaskGraphT, TaskGraphT } from './CPWorkflowTypes';
 
@@ -9,22 +9,30 @@ const emptyGraph = {
 };
 
 const twoTasksGraph: TaskGraphT = {
+    //.......................
+    // pharma1
+    //         a ---+
+    //              |
+    //.......................
+    // pharma2      |
+    //              +-> b
+
     tasks: [
         {
             key: 'a',
             rank: 0,
             worker: 'pharma1',
             status: TupleStatus.done,
-            inputs: [],
-            outputs: [{ id: 'out_model', kind: 'model' }],
+            inputs_specs: [],
+            outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
         },
         {
             key: 'b',
             rank: 1,
             worker: 'pharma2',
             status: TupleStatus.failed,
-            inputs: [{ id: 'in_model', kind: 'model' }],
-            outputs: [],
+            inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
+            outputs_specs: [],
         },
     ],
     edges: [
@@ -50,7 +58,7 @@ const twoTasksLayoutedGraph: LayoutedTaskGraphT = {
             ...twoTasksGraph.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
-                y: 208, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("1 task in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in second row") + 8 ("uneven column top padding")
+                y: 228, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("1 task in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in second row") + 8 ("uneven column top padding")
             },
         },
     ],
@@ -58,6 +66,16 @@ const twoTasksLayoutedGraph: LayoutedTaskGraphT = {
 };
 
 const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
+    //............................
+    // pharma1
+    //         a --------------+
+    //         |               |
+    //         +-> predict_a   |
+    //             |           |
+    //             +-> test_a  |
+    //............................
+    // pharma2                 |
+    //                         +-> b
     tasks: [
         ...twoTasksGraph.tasks,
         {
@@ -65,16 +83,16 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
             rank: 1,
             worker: 'pharma1',
             status: TupleStatus.done,
-            inputs: [{ id: 'in_model', kind: 'model' }],
-            outputs: [{ id: 'out_model', kind: 'model' }],
+            inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
+            outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
         },
         {
             key: 'test_a',
             rank: 2,
             worker: 'pharma1',
             status: TupleStatus.done,
-            inputs: [{ id: 'in_model', kind: 'model' }],
-            outputs: [{ id: 'perf', kind: 'performance' }],
+            inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
+            outputs_specs: [{ identifier: 'perf', kind: 'ASSET_PERFORMANCE' }],
         },
     ],
     edges: [
@@ -107,21 +125,21 @@ const twoTasksPlusPredictAndTestTupleLayoutedGraph: LayoutedTaskGraphT = {
             ...twoTasksPlusPredictAndTestTupleGraph.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
-                y: 548, // 3 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("3 tasks in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in the row") + 8 ("uneven column top padding")
+                y: 608, // 3 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("3 tasks in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in the row") + 8 ("uneven column top padding")
             },
         },
         {
             ...twoTasksPlusPredictAndTestTupleGraph.tasks[2],
             position: {
                 x: 30, // 0 ("in first column") + PREDICT_TASK_LEFT_PADDING
-                y: 170, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("second task in the row")
+                y: 190, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("second task in the row")
             },
         },
         {
             ...twoTasksPlusPredictAndTestTupleGraph.tasks[3],
             position: {
                 x: 60, // 0 ("in first column") + PREDICT_TASK_LEFT_PADDING
-                y: 340, // 2 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("thirsd task in the row")
+                y: 380, // 2 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("thirsd task in the row")
             },
         },
     ],
@@ -129,16 +147,19 @@ const twoTasksPlusPredictAndTestTupleLayoutedGraph: LayoutedTaskGraphT = {
 };
 
 const compositeAndAggregateGraph: TaskGraphT = {
+    //............................
+    // pharma1
+    //         composite_a -> aggregate_a -> composite_b
     tasks: [
         {
             key: 'composite_a',
             rank: 0,
             worker: 'pharma1',
             status: TupleStatus.done,
-            inputs: [],
-            outputs: [
-                { id: 'out_head_model', kind: 'model' },
-                { id: 'out_trunk_model', kind: 'model' },
+            inputs_specs: [],
+            outputs_specs: [
+                { identifier: 'out_head_model', kind: 'ASSET_MODEL' },
+                { identifier: 'out_trunk_model', kind: 'ASSET_MODEL' },
             ],
         },
         {
@@ -146,19 +167,19 @@ const compositeAndAggregateGraph: TaskGraphT = {
             rank: 1,
             worker: 'pharma1',
             status: TupleStatus.failed,
-            inputs: [{ id: 'in_models', kind: 'model' }],
-            outputs: [{ id: 'out_model', kind: 'model' }],
+            inputs_specs: [{ identifier: 'in_models', kind: 'ASSET_MODEL' }],
+            outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
         },
         {
             key: 'composite_b',
             rank: 2,
             worker: 'pharma1',
             status: TupleStatus.done,
-            inputs: [
-                { id: 'in_head_model', kind: 'model' },
-                { id: 'in_trunk_model', kind: 'model' },
+            inputs_specs: [
+                { identifier: 'in_head_model', kind: 'ASSET_MODEL' },
+                { identifier: 'in_trunk_model', kind: 'ASSET_MODEL' },
             ],
-            outputs: [],
+            outputs_specs: [],
         },
     ],
     edges: [

--- a/src/modules/cpWorkflow/CPWorkflowLayout.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.ts
@@ -198,9 +198,12 @@ function findSecondaryBranches(
             .length;
     }
 
+    const SECONDARY_BRANCH_MAX_LENGTH = 2;
+
     // Recusrsive function to walk through parent tasks as long as it is a linear chain to find the secondary branch
     function recFindSecondaryBranch(
         task: TaskT,
+        taskRankInSecondaryBranchFromLeaf: number,
         graph: TaskGraphT,
         taskKeyToParentTasksMap: { [task_key: string]: TaskT[] },
         tasksInSecondaryBranches: { [task_key: string]: number }
@@ -215,11 +218,16 @@ function findSecondaryBranches(
         } else if (parents.length === 1) {
             const parent = parents[0];
 
-            if (computeNbOfChildren(graph, parent) === 1) {
+            if (
+                taskRankInSecondaryBranchFromLeaf + 1 <
+                    SECONDARY_BRANCH_MAX_LENGTH &&
+                computeNbOfChildren(graph, parent) === 1
+            ) {
                 // The parent has no other child than this task, it is part of the secondary branch
                 // We recursively continue to walk through its parents
                 const parentRankInSecondaryBranch = recFindSecondaryBranch(
                     parent,
+                    taskRankInSecondaryBranchFromLeaf + 1,
                     graph,
                     taskKeyToParentTasksMap,
                     tasksInSecondaryBranches
@@ -255,6 +263,7 @@ function findSecondaryBranches(
     for (const task of endOfSecondaryBranches) {
         recFindSecondaryBranch(
             task,
+            0,
             graph,
             taskKeyToParentTasksMap,
             taskRanksInSecondaryBranch

--- a/src/modules/cpWorkflow/CPWorkflowLayout.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.ts
@@ -7,7 +7,7 @@ import {
 export const NODE_WIDTH = 250;
 export const NODE_HEIGHT = 119;
 
-const NODE_BOTTOM_MARGIN = 51; // Add margin to the node height avoid stacking nodes
+const NODE_BOTTOM_MARGIN = 71; // Add margin to the node height avoid stacking nodes
 const ROW_BOTTOM_MARGIN = 30;
 const CELL_WIDTH = NODE_WIDTH + 150;
 
@@ -189,7 +189,7 @@ function findSecondaryBranches(
         );
         return (
             outputKinds.size === 1 &&
-            outputKinds.values().next().value === 'performance'
+            outputKinds.values().next().value === 'ASSET_PERFORMANCE'
         );
     }
 
@@ -210,7 +210,7 @@ function findSecondaryBranches(
         );
         if (parents.length === 0) {
             // The secondary branch is not connected to the rest of the workflow
-            // Let us not tune the layout for this specific case
+            // Let us not tune the layout for this specific case. Could be a single train task chain
             return null;
         } else if (parents.length === 1) {
             const parent = parents[0];
@@ -279,7 +279,12 @@ export function computeLayout(graph: TaskGraphT): LayoutedTaskGraphT {
         const parentTask = taskKeyToTaskMap[edge.source_task_key];
 
         const parentTasks = taskKeyToParentTasksMap[targetTaskKey] ?? [];
-        taskKeyToParentTasksMap[targetTaskKey] = [...parentTasks, parentTask];
+        if (!parentTasks.includes(parentTask)) {
+            taskKeyToParentTasksMap[targetTaskKey] = [
+                ...parentTasks,
+                parentTask,
+            ];
+        }
     }
 
     const taskRankInSecondaryBranch = findSecondaryBranches(

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -25,9 +25,9 @@ export type PositionedTaskT = TaskT & {
 
 type EdgeT = {
     source_task_key: string;
-    source_output_name: string;
+    source_output_identifier: string;
     target_task_key: string;
-    target_input_name: string;
+    target_input_identifier: string;
 };
 
 export type TaskGraphT = {

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -1,4 +1,4 @@
-import { TaskStatus } from '@/modules/tasks/TasksTypes';
+import { TupleStatus } from '@/modules/tasks/TuplesTypes';
 
 type PositionT = {
     x: number;
@@ -6,20 +6,20 @@ type PositionT = {
 };
 
 type PlugT = {
-    id: string;
+    identifier: string;
     kind: string;
 };
 
-export type WorkflowTaskT = {
+export type TaskT = {
     key: string;
     rank: number;
     worker: string;
-    status: TaskStatus;
-    inputs: PlugT[];
-    outputs: PlugT[];
+    status: TupleStatus;
+    inputs_specs: PlugT[];
+    outputs_specs: PlugT[];
 };
 
-export type PositionedWorkflowTaskT = WorkflowTaskT & {
+export type PositionedTaskT = TaskT & {
     position: PositionT;
 };
 
@@ -31,11 +31,11 @@ type EdgeT = {
 };
 
 export type TaskGraphT = {
-    tasks: WorkflowTaskT[];
+    tasks: TaskT[];
     edges: EdgeT[];
 };
 
 export type LayoutedTaskGraphT = {
-    tasks: PositionedWorkflowTaskT[];
+    tasks: PositionedTaskT[];
     edges: EdgeT[];
 };

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -19,7 +19,7 @@ export type TaskT = {
     outputs_specs: PlugT[];
 };
 
-type PositionedTaskT = TaskT & {
+export type PositionedTaskT = TaskT & {
     position: PositionT;
 };
 

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -1,4 +1,4 @@
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 type PositionT = {
     x: number;
@@ -14,12 +14,12 @@ export type TaskT = {
     key: string;
     rank: number;
     worker: string;
-    status: TupleStatus;
+    status: TaskStatus;
     inputs_specs: PlugT[];
     outputs_specs: PlugT[];
 };
 
-export type PositionedTaskT = TaskT & {
+type PositionedTaskT = TaskT & {
     position: PositionT;
 };
 

--- a/src/modules/cpWorkflow/CPWorkflowUtils.ts
+++ b/src/modules/cpWorkflow/CPWorkflowUtils.ts
@@ -2,7 +2,7 @@ import { Edge, Node, MarkerType } from 'react-flow-renderer';
 
 import {
     LayoutedTaskGraphT,
-    PositionedWorkflowTaskT,
+    PositionedTaskT,
 } from '@/modules/cpWorkflow/CPWorkflowTypes';
 import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
@@ -30,31 +30,29 @@ export const NODE_LABEL_COLOR: Record<TaskStatus, string> = {
 };
 
 export default function makeReactFlowGraph(graphItems: LayoutedTaskGraphT): {
-    nodes: Node<PositionedWorkflowTaskT>[];
+    nodes: Node<PositionedTaskT>[];
     edges: Edge[];
 } {
-    const nodes = graphItems.tasks.map(
-        (task): Node<PositionedWorkflowTaskT> => {
-            return {
-                id: task.key,
-                type: 'taskNode',
-                position: {
-                    x: task.position.x,
-                    y: task.position.y,
-                },
-                data: task,
-                style: {
-                    borderRadius: '4px',
-                    zIndex: '3',
-                    width: NODE_WIDTH,
-                    border: `2px solid ${NODE_BORDER_COLOR[task.status]}`,
-                    color: NODE_LABEL_COLOR[task.status],
-                    background: 'white',
-                    cursor: 'pointer',
-                },
-            };
-        }
-    );
+    const nodes = graphItems.tasks.map((task): Node<PositionedTaskT> => {
+        return {
+            id: task.key,
+            type: 'taskNode',
+            position: {
+                x: task.position.x,
+                y: task.position.y,
+            },
+            data: task,
+            style: {
+                borderRadius: '4px',
+                zIndex: '3',
+                width: NODE_WIDTH,
+                border: `2px solid ${NODE_BORDER_COLOR[task.status]}`,
+                color: NODE_LABEL_COLOR[task.status],
+                background: 'white',
+                cursor: 'pointer',
+            },
+        };
+    });
 
     const edges: Edge[] = graphItems.edges.map((edge) => {
         return {

--- a/src/modules/cpWorkflow/CPWorkflowUtils.ts
+++ b/src/modules/cpWorkflow/CPWorkflowUtils.ts
@@ -61,15 +61,15 @@ export default function makeReactFlowGraph(graphItems: LayoutedTaskGraphT): {
             id:
                 edge.source_task_key +
                 '.' +
-                edge.source_output_name +
+                edge.source_output_identifier +
                 '->' +
                 edge.target_task_key +
                 '.' +
-                edge.target_input_name,
+                edge.target_input_identifier,
             source: edge.source_task_key,
-            sourceHandle: edge.source_output_name,
+            sourceHandle: edge.source_output_identifier,
             target: edge.target_task_key,
-            targetHandle: edge.target_input_name,
+            targetHandle: edge.target_input_identifier,
             markerEnd: {
                 type: MarkerType.ArrowClosed,
                 color: '#373737',

--- a/src/routes/computePlanDetails/components/TasksWorkflow.tsx
+++ b/src/routes/computePlanDetails/components/TasksWorkflow.tsx
@@ -17,7 +17,7 @@ import {
     NODE_WIDTH,
     NODE_HEIGHT,
 } from '@/modules/cpWorkflow/CPWorkflowLayout';
-import { PositionedWorkflowTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
+import { PositionedTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
 import makeReactFlowGraph, {
     MIN_ZOOM_LEVEL,
     MAX_ZOOM_LEVEL,
@@ -55,10 +55,7 @@ const TasksWorkflow = (): JSX.Element => {
         setEdges(rfGraph.edges);
     }, [layoutedGraph, setNodes, setEdges]);
 
-    const onNodeClick = (
-        e: React.MouseEvent,
-        node: Node<PositionedWorkflowTaskT>
-    ) => {
+    const onNodeClick = (e: React.MouseEvent, node: Node<PositionedTaskT>) => {
         if (node) {
             setSelectedTaskKey(node.data.key);
         }

--- a/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
+++ b/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
@@ -21,12 +21,12 @@ const TaskNode = ({ data }: TaskNodeProps) => {
     return (
         <>
             {/*Handles*/}
-            {data.inputs.map((value, index) => (
-                <Box key={value.id}>
+            {data.inputs_specs.map((value, index) => (
+                <Box key={value.identifier}>
                     <Handle
                         type="target"
                         position={Position.Left}
-                        id={value.id}
+                        id={value.identifier}
                         style={{
                             borderRadius: handleRadius,
                             top: handleTopMargin + handleElementMargin * index,
@@ -39,12 +39,12 @@ const TaskNode = ({ data }: TaskNodeProps) => {
                     />
                 </Box>
             ))}
-            {data.outputs.map((value, index) => (
-                <Box key={value.id}>
+            {data.outputs_specs.map((value, index) => (
+                <Box key={value.identifier}>
                     <Handle
                         type="source"
                         position={Position.Right}
-                        id={value.id}
+                        id={value.identifier}
                         style={{
                             borderRadius: handleRadius,
                             top: handleTopMargin + handleElementMargin * index,
@@ -90,16 +90,22 @@ const TaskNode = ({ data }: TaskNodeProps) => {
                 >
                     <Flex display="flex" gap="6px">
                         <Box flex="50%" textAlign="left">
-                            {data.inputs.map((value) => (
-                                <Text margin="0 auto 0 3px" key={value.id}>
-                                    {value.id}
+                            {data.inputs_specs.map((value) => (
+                                <Text
+                                    margin="0 auto 0 3px"
+                                    key={value.identifier}
+                                >
+                                    {value.identifier}
                                 </Text>
                             ))}
                         </Box>
                         <Box flex="50%" textAlign="right">
-                            {data.outputs.map((value) => (
-                                <Text margin="0 3px 0 auto" key={value.id}>
-                                    {value.id}
+                            {data.outputs_specs.map((value) => (
+                                <Text
+                                    margin="0 3px 0 auto"
+                                    key={value.identifier}
+                                >
+                                    {value.identifier}
                                 </Text>
                             ))}
                         </Box>

--- a/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
+++ b/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
@@ -4,14 +4,14 @@ import { Handle, Position } from 'react-flow-renderer';
 
 import { Box, Text, Flex } from '@chakra-ui/react';
 
-import { PositionedWorkflowTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
+import { PositionedTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
 import {
     NODE_BORDER_COLOR,
     NODE_LABEL_COLOR,
 } from '@/modules/cpWorkflow/CPWorkflowUtils';
 
 type TaskNodeProps = {
-    data: PositionedWorkflowTaskT;
+    data: PositionedTaskT;
 };
 
 const TaskNode = ({ data }: TaskNodeProps) => {


### PR DESCRIPTION
A side effect of extracting information from the db was that the asset kind names was different than the hardcoded ones.

Also, some following tasks have 2 edges connecting them: this implies to update the way to find secondary branches.

Finally, 3 fields in the response changes names:
- for maintenance purpose, we decided to match the name in db: id -> identifier
- implementation constraints made us change inputs -> inputs_specs and outputs -> outputs_specs

companion PR:
[backend](https://github.com/Substra/substra-backend/pull/486)