### PR TITLE
fix: empty inputs make the drawer crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Display user description after role update (#117)
 -   CP workflow graph is now built independently of the task categories (#114)
+-   Empty task inputs make drawer crash (#120)
 
 ## [0.35.0] - 2022-09-26
 

--- a/src/routes/tasks/components/TaskInputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskInputsDrawerSection.tsx
@@ -385,15 +385,19 @@ const TaskInputsDrawerSection = ({
                     ([
                         identifier,
                         { algoInput: algoInput, inputs: inputs },
-                    ]) => (
-                        <TaskInputSectionEntry
-                            key={identifier}
-                            identifier={identifier}
-                            algoInput={algoInput}
-                            inputs={inputs}
-                            parentTasks={parentTasks}
-                        />
-                    )
+                    ]) => {
+                        if (inputs.length > 0) {
+                            return (
+                                <TaskInputSectionEntry
+                                    key={identifier}
+                                    identifier={identifier}
+                                    algoInput={algoInput}
+                                    inputs={inputs}
+                                    parentTasks={parentTasks}
+                                />
+                            );
+                        }
+                    }
                 )}
         </DrawerSection>
     );


### PR DESCRIPTION
Signed-off-by: Hamdy Dakkak <hamdy.dakkak@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->


## Description

<!--- Describe your choices and changes in detail -->
Handle empty task inputs case : display an empty section/row.

## How to test

Open a failed task drawer.
