### PR TITLE
fix: Open task drawer directly in cp details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Removed task categories from the frontend (#119)
+-   Open task drawer directly in cp details page (#122)
 
 ## [0.36.0] - 2022-10-03
 

--- a/src/components/TasksTable.tsx
+++ b/src/components/TasksTable.tsx
@@ -334,11 +334,25 @@ const TasksTable = ({
                                         <ClickableTr
                                             key={task.key}
                                             onClick={() =>
-                                                setLocationPreserveParams(
-                                                    compilePath(PATHS.TASK, {
-                                                        key: task.key,
-                                                    })
-                                                )
+                                                computePlan
+                                                    ? setLocationPreserveParams(
+                                                          compilePath(
+                                                              PATHS.COMPUTE_PLAN_TASK,
+                                                              {
+                                                                  key: task.compute_plan_key,
+                                                                  taskKey:
+                                                                      task.key,
+                                                              }
+                                                          )
+                                                      )
+                                                    : setLocationPreserveParams(
+                                                          compilePath(
+                                                              PATHS.TASK,
+                                                              {
+                                                                  key: task.key,
+                                                              }
+                                                          )
+                                                      )
                                             }
                                         >
                                             <Td>

--- a/src/routes/computePlanDetails/ComputePlanTasks.tsx
+++ b/src/routes/computePlanDetails/ComputePlanTasks.tsx
@@ -23,7 +23,7 @@ import {
     retrieveComputePlan,
     retrieveComputePlanTasks,
 } from '@/modules/computePlans/ComputePlansSlice';
-import { PATHS } from '@/paths';
+import { compilePath, PATHS } from '@/paths';
 import { ROUTES } from '@/routes';
 import TaskDrawer from '@/routes/tasks/components/TaskDrawer';
 
@@ -119,7 +119,11 @@ const Tasks = ({ computePlanKey }: { computePlanKey: string }): JSX.Element => {
         <Flex direction="column" alignItems="stretch" flexGrow={1}>
             <TaskDrawer
                 onClose={() =>
-                    setLocationPreserveParams(PATHS.COMPUTE_PLAN_TASKS)
+                    setLocationPreserveParams(
+                        compilePath(PATHS.COMPUTE_PLAN_TASKS, {
+                            key: computePlanKey,
+                        })
+                    )
                 }
                 taskKey={taskKey}
                 setPageTitle={true}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1200346939311555/1203099483741820)

## Description

Clicking a task in the task table on the cp details page previously navigated to the tasks page to open the task drawer. Now the task drawer is directly opened in cp details page.