### PR TITLE
fix: UI and markup glitches on login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Removed task categories from the frontend (#119)
 -   Open task drawer directly in cp details page (#122)
 
+### Fixed
+
+-   UI and markup glitches on login page (#123)
+
 ## [0.36.0] - 2022-10-03
 
 ### Changed
 
 -   CP workflow graph is now built independently of the task categories (#114)
+-   Container build error logs are now accessible
 
 ### Fixed
 
 -   Display user description after role update (#117)
 -   Empty task inputs make drawer crash (#120)
-
-### Changed
-
--   Container build error logs are now accessible
 
 ## [0.35.0] - 2022-09-26
 

--- a/src/routes/login/Login.tsx
+++ b/src/routes/login/Login.tsx
@@ -46,32 +46,40 @@ const Login = (): JSX.Element => {
     }, [forceLogout, authenticated, dispatch, setLocation, nextLocation]);
 
     return (
-        <HStack backgroundColor="#F7FAFC" flex="1" spacing="0">
+        <HStack
+            backgroundColor="#F7FAFC"
+            flex="1"
+            spacing="0"
+            alignItems="stretch"
+        >
             <VStack
                 height="100vh"
                 width="500px"
                 backgroundColor="white"
                 alignItems="flex-start"
                 justifyContent="space-between"
+                padding="8"
+                spacing="8"
             >
-                <Box padding="8">
+                <Box>
                     <SubstraLogoBlack />
                 </Box>
                 <Box alignItems="center" width="100%">
                     <LoginForm />
                 </Box>
-                <Text color="gray.500" fontSize="xs" paddingX="5" paddingY="8">
-                    Frontend vers.
-                    {__APP_VERSION__}
+                <Text color="gray.500" fontSize="xs">
+                    {`Frontend v.  ${__APP_VERSION__}`}
                 </Text>
             </VStack>
             <Flex
                 flexDirection="column"
-                height="100vh"
+                flexGrow="1"
+                alignItems="flex-start"
                 padding="10%"
                 backgroundImage={LoginBackground}
                 justifyContent="center"
                 style={{
+                    backgroundPosition: 'center center',
                     backgroundRepeat: 'no-repeat',
                     backgroundSize: 'cover',
                 }}
@@ -80,15 +88,19 @@ const Login = (): JSX.Element => {
                     Unlock AI, break data silos, and protect privacy with our
                     Federated Learning software
                 </Text>
-                <Link
-                    href="https://github.com/Substra/substra-frontend"
-                    isExternal
+                <Button
+                    as={Link}
+                    variant="outline"
+                    colorScheme="whiteAlpha"
                     color="white"
+                    href="https://docs.substra.org/"
+                    _hover={{
+                        textDecoration: 'none',
+                    }}
+                    isExternal
                 >
-                    <Button variant="outline" colorScheme="whiteAlpha">
-                        <Text color="white">Learn more on Github!</Text>
-                    </Button>
-                </Link>
+                    Learn more!
+                </Button>
             </Flex>
         </HStack>
     );


### PR DESCRIPTION
## Description

The login page had a handful of glitches:
* in the left section, horizontal padding was inconsistent
* in the left section, app version was displayed as a weird abbreviation: "vers." with no space between "vers." and the version number
* in the right section, on large screens, there was whitespace on the right hand side
* in the right section, the background image was not centered, making the person disappear on smaller screens
* in the right section, the "Learn more" link pointed to a github repo with no resources to learn more
* in the right section, the "Learn more" link markup was a div within a button within a link. It's changed into a simple link.

## Linked to these asana cards:
* https://app.asana.com/0/1200346939311555/1203091499867938
* https://app.asana.com/0/1200346939311555/1203030647785903