### PR TITLE
feat : add cp creator data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+-   CP creators are available data (#124)
+
 ### Changed
 
 -   Get tasks inputs & outputs assets from new endpoints (#144)

--- a/src/components/TableFilterTags.tsx
+++ b/src/components/TableFilterTags.tsx
@@ -132,6 +132,10 @@ export const StatusTableFilterTag = (): JSX.Element | null => (
     />
 );
 
+export const CreatorTableFilterTag = (): JSX.Element | null => (
+    <MultipleFilterTag label="Creator" syncedArrayStateName="creator" />
+);
+
 export const FavoritesTableFilterTag = (): JSX.Element | null => {
     const [favoritesOnly, setFavoritesOnly] = useFavoritesOnly();
 

--- a/src/components/TableFilters/CreatorTableFilter.tsx
+++ b/src/components/TableFilters/CreatorTableFilter.tsx
@@ -71,7 +71,6 @@ const CreatorTableFilter = (): JSX.Element => {
     };
 
     const externalOption = {
-        // TODO: make sure the Orc turns null values to external
         value: 'external',
         label: 'External',
         description: 'Compute plan created by other organizations',

--- a/src/components/TableFilters/CreatorTableFilter.tsx
+++ b/src/components/TableFilters/CreatorTableFilter.tsx
@@ -1,0 +1,159 @@
+import { useEffect } from 'react';
+
+import { Box, Checkbox, Text, VStack } from '@chakra-ui/react';
+
+import useAppSelector from '@/hooks/useAppSelector';
+import useDispatchWithAutoAbort from '@/hooks/useDispatchWithAutoAbort';
+import useSelection from '@/hooks/useSelection';
+import {
+    useCreator,
+    useMatch,
+    useOrdering,
+    usePage,
+} from '@/hooks/useSyncedState';
+import { useTableFilterCallbackRefs } from '@/hooks/useTableFilters';
+import { listUsers } from '@/modules/users/UsersSlice';
+
+import {
+    getOptionDescription,
+    getOptionLabel,
+    getOptionValue,
+} from './TableFilterCheckboxes';
+
+const CreatorTableFilter = (): JSX.Element => {
+    {
+        /* Available options
+        - Me (compute plans created by myself)
+        - Externals (users of an other organization, is set as external in the backend)
+        - All the users of my organization
+    */
+    }
+    const dispatchWithAutoAbort = useDispatchWithAutoAbort();
+    const [page] = usePage();
+    const [match] = useMatch();
+    const [ordering] = useOrdering('username');
+
+    useEffect(() => {
+        return dispatchWithAutoAbort(listUsers({ page, ordering, match }));
+    }, [page, ordering, match, dispatchWithAutoAbort]);
+
+    const users = useAppSelector((state) => state.users.users);
+
+    const [tmpCreator, onTmpCreatorChange, resetTmpCreator, setTmpCreator] =
+        useSelection();
+
+    const [activeCreator] = useCreator();
+    const { clearRef, applyRef, resetRef } =
+        useTableFilterCallbackRefs('creator');
+
+    clearRef.current = (urlSearchParams) => {
+        resetTmpCreator();
+        urlSearchParams.delete('creator');
+    };
+
+    applyRef.current = (urlSearchParams) => {
+        if (tmpCreator.length > 0) {
+            urlSearchParams.set('creator', tmpCreator.join(','));
+        } else {
+            urlSearchParams.delete('creator');
+        }
+    };
+
+    resetRef.current = () => {
+        setTmpCreator(activeCreator);
+    };
+
+    const me = useAppSelector((state) => state.me.info.user);
+    const meOption = {
+        value: me,
+        label: `Me (${me})`,
+        description: 'Compute plan that I created',
+    };
+
+    const externalOption = {
+        // TODO: make sure the Orc turns null values to external
+        value: 'external',
+        label: 'External',
+        description: 'Compute plan created by other organizations',
+    };
+
+    const options = Object.values(users).map((user) => ({
+        value: user.username,
+        label: user.username,
+    }));
+
+    return (
+        <Box w="100%" paddingY="5" paddingX="30px">
+            <Text color="gray.500" fontSize="xs" mb="2.5">
+                Filter by
+            </Text>
+            <VStack spacing="2.5" alignItems="flex-start">
+                <Checkbox
+                    value={getOptionValue(meOption)}
+                    isChecked={tmpCreator.includes(getOptionValue(meOption))}
+                    onChange={onTmpCreatorChange(getOptionValue(meOption))}
+                    colorScheme="primary"
+                    key={getOptionValue(meOption)}
+                    alignItems="start"
+                >
+                    <Text fontSize="sm" lineHeight="1.2">
+                        {getOptionLabel(meOption)}
+                    </Text>
+                    {getOptionDescription(meOption) && (
+                        <Text color="gray.500" fontSize="xs">
+                            {getOptionDescription(meOption)}
+                        </Text>
+                    )}
+                </Checkbox>
+                <Checkbox
+                    value={getOptionValue(externalOption)}
+                    isChecked={tmpCreator.includes(
+                        getOptionValue(externalOption)
+                    )}
+                    onChange={onTmpCreatorChange(
+                        getOptionValue(externalOption)
+                    )}
+                    colorScheme="primary"
+                    key={getOptionValue(externalOption)}
+                    alignItems="start"
+                >
+                    <Text fontSize="sm" lineHeight="1.2">
+                        {getOptionLabel(externalOption)}
+                    </Text>
+                    {getOptionDescription(externalOption) && (
+                        <Text color="gray.500" fontSize="xs">
+                            {getOptionDescription(externalOption)}
+                        </Text>
+                    )}
+                </Checkbox>
+                <Text color="gray.500" fontSize="xs" mb="2.5">
+                    From my organization
+                </Text>
+                {options.map((option) => (
+                    <Checkbox
+                        value={getOptionValue(option)}
+                        isChecked={tmpCreator.includes(getOptionValue(option))}
+                        onChange={onTmpCreatorChange(getOptionValue(option))}
+                        colorScheme="primary"
+                        key={getOptionValue(option)}
+                        alignItems="start"
+                    >
+                        <Text fontSize="sm" lineHeight="1.2">
+                            {getOptionLabel(option)}
+                        </Text>
+                        {getOptionDescription(option) && (
+                            <Text color="gray.500" fontSize="xs">
+                                {getOptionDescription(option)}
+                            </Text>
+                        )}
+                    </Checkbox>
+                ))}
+            </VStack>
+        </Box>
+    );
+};
+
+CreatorTableFilter.filterTitle = 'Creator';
+CreatorTableFilter.filterField = 'creator';
+
+export default CreatorTableFilter;

--- a/src/components/TableFilters/TableFilterCheckboxes.tsx
+++ b/src/components/TableFilters/TableFilterCheckboxes.tsx
@@ -2,13 +2,13 @@ import { Box, Checkbox, VStack, Text } from '@chakra-ui/react';
 
 type OptionT = { value: string; label: string; description?: string } | string;
 
-const getOptionValue = (option: OptionT) =>
+export const getOptionValue = (option: OptionT) =>
     typeof option === 'string' ? option : option.value;
 
-const getOptionLabel = (option: OptionT) =>
+export const getOptionLabel = (option: OptionT) =>
     typeof option === 'string' ? option : option.label;
 
-const getOptionDescription = (option: OptionT) =>
+export const getOptionDescription = (option: OptionT) =>
     typeof option === 'string' ? null : option.description;
 
 type TableFilterCheckboxesProps = {

--- a/src/features/customColumns/CustomColumnsUtils.ts
+++ b/src/features/customColumns/CustomColumnsUtils.ts
@@ -4,6 +4,7 @@ export enum GeneralColumnName {
     status = 'Status',
     creation = 'Creation',
     dates = 'Start date / End date / Duration',
+    creator = 'Creator',
 }
 
 export const GENERAL_COLUMNS: ColumnT[] = Object.values(GeneralColumnName).map(

--- a/src/hooks/useSyncedState.ts
+++ b/src/hooks/useSyncedState.ts
@@ -209,6 +209,7 @@ export const useCanAccessLogs = () =>
 export const useCanProcess = () => useSyncedStringArrayState('can_process', []);
 export const useOwner = () => useSyncedStringArrayState('owner', []);
 export const useStatus = () => useSyncedStringArrayState('status', []);
+export const useCreator = () => useSyncedStringArrayState('creator', []);
 export const useWorker = () => useSyncedStringArrayState('worker', []);
 
 // Common dates states

--- a/src/modules/computePlans/ComputePlansTypes.ts
+++ b/src/modules/computePlans/ComputePlansTypes.ts
@@ -45,6 +45,7 @@ export type ComputePlanStubT = {
     delete_intermediary_models: boolean;
     name: string;
     creation_date: string;
+    creator: string;
     metadata: { [key: string]: string };
     start_date?: string;
     end_date?: string;

--- a/src/routes/computePlanDetails/components/DetailsSidebar.tsx
+++ b/src/routes/computePlanDetails/components/DetailsSidebar.tsx
@@ -124,6 +124,9 @@ const DetailsSidebar = (): JSX.Element => {
                             title="Created"
                             date={computePlan.creation_date}
                         />
+                        <DrawerSectionEntry title="Creator">
+                            <Text>{computePlan.creator}</Text>
+                        </DrawerSectionEntry>
                         <DrawerSectionEntry title="Duration">
                             <Timing asset={computePlan} />
                             <Duration asset={computePlan} />

--- a/src/routes/computePlans/ComputePlans.tsx
+++ b/src/routes/computePlans/ComputePlans.tsx
@@ -12,6 +12,7 @@ import useFavoriteComputePlans from '@/hooks/useFavoriteComputePlans';
 import { useLocalStorageKeyArrayState } from '@/hooks/useLocalStorageState';
 import {
     useCreationDate,
+    useCreator,
     useDuration,
     useEndDate,
     useFavoritesOnly,
@@ -37,6 +38,7 @@ import RefreshButton from '@/components/RefreshButton';
 import SearchBar from '@/components/SearchBar';
 import { EmptyTr, Tbody } from '@/components/Table';
 import {
+    CreatorTableFilterTag,
     DateFilterTag,
     DurationFilterTag,
     FavoritesTableFilterTag,
@@ -54,6 +56,7 @@ import {
     EndDateTableFilter,
     MetadataTableFilter,
 } from '@/components/TableFilters';
+import CreatorTableFilter from '@/components/TableFilters/CreatorTableFilter';
 import TablePagination from '@/components/TablePagination';
 
 import ComputePlanTHead from './components/ComputePlanTHead';
@@ -72,6 +75,8 @@ const ComputePlans = (): JSX.Element => {
     const { endDateBefore, endDateAfter } = useEndDate();
     const { durationMin, durationMax } = useDuration();
     const [metadata] = useMetadataString();
+    const [creator] = useCreator();
+
     const {
         state: selectedComputePlans,
         addItem: selectComputePlan,
@@ -109,6 +114,7 @@ const ComputePlans = (): JSX.Element => {
             metadata,
             duration_min: durationMin,
             duration_max: durationMax,
+            creator: creator,
         }),
         [
             match,
@@ -123,6 +129,7 @@ const ComputePlans = (): JSX.Element => {
             metadata,
             durationMin,
             durationMax,
+            creator,
         ]
     );
 
@@ -201,6 +208,7 @@ const ComputePlans = (): JSX.Element => {
                             <ComputePlanFavoritesTableFilter
                                 favorites={favorites}
                             />
+                            <CreatorTableFilter />
                             <CreationDateTableFilter />
                             <StartDateTableFilter />
                             <EndDateTableFilter />
@@ -243,6 +251,7 @@ const ComputePlans = (): JSX.Element => {
                     <TableFilterTags>
                         <StatusTableFilterTag />
                         <FavoritesTableFilterTag />
+                        <CreatorTableFilterTag />
                         <DateFilterTag
                             urlParam="creation_date"
                             label="Creation date"

--- a/src/routes/computePlans/components/ComputePlanTHead.tsx
+++ b/src/routes/computePlans/components/ComputePlanTHead.tsx
@@ -132,6 +132,31 @@ const ColumnTh = ({ column, onPopoverOpen }: ColumnThProps): JSX.Element => {
                 ]}
             />
         );
+    } else if (
+        column.type === 'general' &&
+        column.name === GeneralColumnName.creator
+    ) {
+        return (
+            <OrderingTh
+                minWidth="125px"
+                //TODO: use the right number value
+                openFilters={() => onPopoverOpen(1)}
+                options={[
+                    {
+                        label: 'Creator',
+                        asc: {
+                            label: `Sort creator Z -> A`,
+                            value: `-creator`,
+                        },
+                        desc: {
+                            label: `Sort creator A -> Z`,
+                            value: `creator`,
+                        },
+                    },
+                ]}
+                {...bottomBorderProps}
+            />
+        );
     } else {
         return <Th>{`Unknown column ${column.name}`}</Th>;
     }

--- a/src/routes/computePlans/components/ComputePlanTr.tsx
+++ b/src/routes/computePlans/components/ComputePlanTr.tsx
@@ -61,6 +61,15 @@ const ColumnTd = ({ column, computePlan }: ColumnTdProps) => {
                 <Duration asset={computePlan} />
             </Td>
         );
+    } else if (
+        column.type === 'general' &&
+        column.name === GeneralColumnName.creator
+    ) {
+        return (
+            <Td fontSize="xs" whiteSpace="nowrap">
+                <Text>{computePlan.creator ?? '-'}</Text>
+            </Td>
+        );
     } else {
         return (
             <Td>


### PR DESCRIPTION
Signed-off-by: Hamdy Dakkak <hamdy.dakkak@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Companion PR backend : https://github.com/Substra/substra-backend/pull/511

Adding the creator field in the compute plan page first. This implies:
- Adding a creator column
- Adding a creator field in the cp detail page
- Allow filtering on a cp creator

NB: in the backend, the proposition we made was to use creator is `null` for the external users, as this value is not registered in the orchestrator. This supposition has to be validated in the next Architecture Advisory Forum.


## Link to this asana card
[ASANA TASK](https://app.asana.com/0/1200346939311555/1203055070399486)

## Screenshots

<img width="708" alt="Capture d’écran 2022-10-04 à 17 59 14" src="https://user-images.githubusercontent.com/44287876/193870246-695494e3-7c1e-4f81-bf69-736ee9b4dee9.png">
