### PR TITLE
fix: remove algo from newsfeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Removed task categories from the frontend (#119)
 -   Open task drawer directly in cp details page (#122)
+-   Algo creation events aren't included in newsfeed anymore (#127)
 
 ### Fixed
 

--- a/src/components/layout/header/NewsFeedCard.tsx
+++ b/src/components/layout/header/NewsFeedCard.tsx
@@ -75,19 +75,12 @@ const COMPUTE_PLAN_STATUS_PATH: Record<NewsItemStatus, string> = {
     STATUS_FAILED: PATHS.COMPUTE_PLAN_TASK,
     STATUS_CANCELED: PATHS.COMPUTE_PLAN_TASKS,
 };
-const NON_CP_PATH: Record<
-    Exclude<NewsItemAssetKind, NewsItemAssetKind.computePlan>,
-    string
-> = {
-    ASSET_ALGO: PATHS.ALGO,
-    ASSET_DATA_MANAGER: PATHS.DATASET,
-};
 const getItemPath = (newsItem: NewsItemT): string => {
     if (newsItem.asset_kind === NewsItemAssetKind.computePlan) {
         return COMPUTE_PLAN_STATUS_PATH[newsItem.status];
     }
 
-    return NON_CP_PATH[newsItem.asset_kind];
+    return PATHS.DATASET;
 };
 
 const getItemHref = (newsItem: NewsItemT): string => {

--- a/src/modules/newsFeed/NewsFeedTypes.ts
+++ b/src/modules/newsFeed/NewsFeedTypes.ts
@@ -19,13 +19,11 @@ export const getNewsItemStatusLabel = (status: NewsItemStatus): string =>
 
 export enum NewsItemAssetKind {
     computePlan = 'ASSET_COMPUTE_PLAN',
-    algo = 'ASSET_ALGO',
     dataset = 'ASSET_DATA_MANAGER',
 }
 
 const NewsItemAssetLabel: Record<NewsItemAssetKind, string> = {
     ASSET_COMPUTE_PLAN: 'Compute plan',
-    ASSET_ALGO: 'Algorithm',
     ASSET_DATA_MANAGER: 'Dataset',
 };
 

--- a/src/modules/newsFeed/NewsFeedUtils.ts
+++ b/src/modules/newsFeed/NewsFeedUtils.ts
@@ -1,7 +1,6 @@
 import { NewsItemAssetKind } from './NewsFeedTypes';
 
 const ASSET_KIND_LABELS: Record<NewsItemAssetKind, string> = {
-    ASSET_ALGO: 'Algorithm',
     ASSET_COMPUTE_PLAN: 'Compute plan',
     ASSET_DATA_MANAGER: 'Dataset',
 };


### PR DESCRIPTION
Signed-off-by: Jérémy Morel <jeremy.morel@owkin.com>

### Linked to this [ASANA TASK](https://app.asana.com/0/1200346939311555/1202987504140348)

## Description

Algo creation events are not needed in the newsfeed anymore. They're being removed from the values returned by the backend (see companion PR), this PR removes the code that was handling these events.

Companion PR: https://github.com/Substra/substra-backend/pull/514