### PR TITLE
chore: rename tuple things into task things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Removed task categories from the frontend (#119)
 -   Open task drawer directly in cp details page (#122)
 -   Algo creation events aren't included in newsfeed anymore (#127)
+-   Renamed any tuple thing into a task thing (#129)
 
 ### Fixed
 

--- a/src/components/ComputePlanProgressBar.tsx
+++ b/src/components/ComputePlanProgressBar.tsx
@@ -3,10 +3,10 @@ import { Box, HStack } from '@chakra-ui/react';
 import { getStatusStyle } from '@/libs/status';
 import { getStatusCount } from '@/modules/computePlans/ComputePlanUtils';
 import { ComputePlanT } from '@/modules/computePlans/ComputePlansTypes';
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 type ItemProps = {
-    status: TupleStatus;
+    status: TaskStatus;
     count: number;
     total: number;
 };
@@ -26,13 +26,13 @@ const Item = ({ status, count, total }: ItemProps): JSX.Element | null => {
     );
 };
 
-export const tupleStatusOrder: TupleStatus[] = [
-    TupleStatus.done,
-    TupleStatus.doing,
-    TupleStatus.canceled,
-    TupleStatus.failed,
-    TupleStatus.todo,
-    TupleStatus.waiting,
+export const taskStatusOrder: TaskStatus[] = [
+    TaskStatus.done,
+    TaskStatus.doing,
+    TaskStatus.canceled,
+    TaskStatus.failed,
+    TaskStatus.todo,
+    TaskStatus.waiting,
 ];
 
 type ComputePlanProgressBarProps = {
@@ -51,9 +51,9 @@ const ComputePlanProgressBar = ({
             alignItems="stretch"
         >
             {!computePlan.task_count && (
-                <Item status={TupleStatus.waiting} count={1} total={1} />
+                <Item status={TaskStatus.waiting} count={1} total={1} />
             )}
-            {tupleStatusOrder.map((status) => (
+            {taskStatusOrder.map((status) => (
                 <Item
                     key={status}
                     status={status}

--- a/src/components/ComputePlanTaskStatuses.tsx
+++ b/src/components/ComputePlanTaskStatuses.tsx
@@ -3,7 +3,7 @@ import { HStack } from '@chakra-ui/react';
 import { getStatusCount } from '@/modules/computePlans/ComputePlanUtils';
 import { ComputePlanT } from '@/modules/computePlans/ComputePlansTypes';
 
-import { tupleStatusOrder } from '@/components/ComputePlanProgressBar';
+import { taskStatusOrder } from '@/components/ComputePlanProgressBar';
 import Status from '@/components/Status';
 
 const ComputePlanTaskStatuses = ({
@@ -12,7 +12,7 @@ const ComputePlanTaskStatuses = ({
     computePlan: ComputePlanT;
 }): JSX.Element => (
     <HStack spacing="2.5">
-        {tupleStatusOrder.map((status) => (
+        {taskStatusOrder.map((status) => (
             <Status
                 key={status}
                 status={status}

--- a/src/components/Duration.tsx
+++ b/src/components/Duration.tsx
@@ -7,10 +7,10 @@ import {
     ComputePlanT,
     isComputePlan,
 } from '@/modules/computePlans/ComputePlansTypes';
-import { TupleT } from '@/modules/tasks/TuplesTypes';
+import { TaskT } from '@/modules/tasks/TasksTypes';
 
 type DurationProps = {
-    asset: ComputePlanT | TupleT;
+    asset: ComputePlanT | TaskT;
 };
 
 const Duration = ({ asset }: DurationProps): JSX.Element | null => {

--- a/src/components/OmniSearch.tsx
+++ b/src/components/OmniSearch.tsx
@@ -41,12 +41,12 @@ import { ComputePlanStubT } from '@/modules/computePlans/ComputePlansTypes';
 import * as DatasetsApi from '@/modules/datasets/DatasetsApi';
 import { DatasetStubT } from '@/modules/datasets/DatasetsTypes';
 import * as TasksApi from '@/modules/tasks/TasksApi';
-import { TupleT } from '@/modules/tasks/TuplesTypes';
+import { TaskT } from '@/modules/tasks/TasksTypes';
 import { compilePath, PATHS } from '@/paths';
 
 const MAX_ASSETS_PER_SECTION = 5;
 
-type OmniSearchAssetT = 'algo' | 'compute_plan' | 'dataset' | 'tuple';
+type OmniSearchAssetT = 'algo' | 'compute_plan' | 'dataset' | 'task';
 
 type SeeMoreItemT = {
     asset: OmniSearchAssetT;
@@ -64,7 +64,7 @@ const isOmniSearchAsset = (value: unknown): value is OmniSearchAssetT =>
     value === 'algo' ||
     value === 'compute_plan' ||
     value === 'dataset' ||
-    value === 'tuple';
+    value === 'task';
 
 const isSeeMoreItem = (value: unknown): value is SeeMoreItemT => {
     if (value === null || typeof value !== 'object') {
@@ -98,7 +98,7 @@ const ASSET_ITEM_ICONS: Record<OmniSearchAssetT, IconType> = {
     algo: RiCodeSSlashLine,
     compute_plan: RiGitBranchLine,
     dataset: RiDatabase2Line,
-    tuple: RiGitCommitLine,
+    task: RiGitCommitLine,
 };
 
 const AssetItem = ({
@@ -248,9 +248,9 @@ const buildAssetItem = (
     key: asset.key,
 });
 
-const buildTupleItem = (
+const buildTaskItem = (
     assetType: OmniSearchAssetT,
-    asset: TupleT
+    asset: TaskT
 ): AssetItemT => ({
     asset: assetType,
     name: `Task on ${asset.worker}`,
@@ -269,14 +269,14 @@ const ASSET_ITEM_PATHS: Record<OmniSearchAssetT, string> = {
     algo: PATHS.ALGO,
     compute_plan: PATHS.COMPUTE_PLAN,
     dataset: PATHS.DATASET,
-    tuple: PATHS.TASK,
+    task: PATHS.TASK,
 };
 
 const SEE_MORE_ITEM_PATHS: Record<OmniSearchAssetT, string> = {
     algo: PATHS.ALGOS,
     compute_plan: PATHS.COMPUTE_PLANS,
     dataset: PATHS.DATASETS,
-    tuple: PATHS.TASKS,
+    task: PATHS.TASKS,
 };
 
 const OmniSearch = () => {
@@ -286,8 +286,8 @@ const OmniSearch = () => {
     const [algosCount, setAlgosCount] = useState(0);
     const [datasets, setDatasets] = useState<DatasetStubT[]>([]);
     const [datasetsCount, setDatasetsCount] = useState(0);
-    const [tuples, setTuples] = useState<TupleT[]>([]);
-    const [tuplesCount, setTuplesCount] = useState(0);
+    const [tasks, setTasks] = useState<TaskT[]>([]);
+    const [tasksCount, setTasksCount] = useState(0);
 
     const [loading, setLoading] = useState(false);
 
@@ -326,9 +326,9 @@ const OmniSearch = () => {
             ...(datasetsCount > MAX_ASSETS_PER_SECTION
                 ? [buildSeeMoreItem('dataset', datasetsCount)]
                 : []),
-            ...tuples.map((tuple) => buildTupleItem('tuple', tuple)),
-            ...(tuplesCount > MAX_ASSETS_PER_SECTION
-                ? [buildSeeMoreItem('tuple', tuplesCount)]
+            ...tasks.map((task) => buildTaskItem('task', task)),
+            ...(tasksCount > MAX_ASSETS_PER_SECTION
+                ? [buildSeeMoreItem('task', tasksCount)]
                 : []),
         ].map((item, index) => ({ ...item, index }));
     }, [
@@ -338,8 +338,8 @@ const OmniSearch = () => {
         computePlansCount,
         datasets,
         datasetsCount,
-        tuples,
-        tuplesCount,
+        tasks,
+        tasksCount,
     ]);
 
     const algoItems = items.filter((item) => item.asset === 'algo');
@@ -347,7 +347,7 @@ const OmniSearch = () => {
         (item) => item.asset === 'compute_plan'
     );
     const datasetItems = items.filter((item) => item.asset === 'dataset');
-    const tupleItems = items.filter((item) => item.asset === 'tuple');
+    const taskItems = items.filter((item) => item.asset === 'task');
 
     const stateReducer: StateReducerT = useCallback(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -391,8 +391,8 @@ const OmniSearch = () => {
         setAlgosCount(0);
         setDatasets([]);
         setDatasetsCount(0);
-        setTuples([]);
-        setTuplesCount(0);
+        setTasks([]);
+        setTasksCount(0);
     }, []);
 
     const {
@@ -429,16 +429,16 @@ const OmniSearch = () => {
                 AxiosPromise<PaginatedApiResponseT<ComputePlanStubT>>,
                 AxiosPromise<PaginatedApiResponseT<AlgoT>>,
                 AxiosPromise<PaginatedApiResponseT<DatasetStubT>>,
-                AxiosPromise<PaginatedApiResponseT<TupleT>>
+                AxiosPromise<PaginatedApiResponseT<TaskT>>
             ] = [
                 ComputePlansApi.listComputePlans(params, config),
                 AlgosApi.listAlgos(params, config),
                 DatasetsApi.listDatasets(params, config),
-                TasksApi.listTuples(params, config),
+                TasksApi.listTasks(params, config),
             ];
             try {
                 const responses = await Promise.all(promises);
-                const [computePlansData, algosData, datasetsData, tuplesData] =
+                const [computePlansData, algosData, datasetsData, tasksData] =
                     responses.map((response) => response.data);
 
                 setComputePlans(
@@ -449,8 +449,8 @@ const OmniSearch = () => {
                 setAlgosCount(algosData['count']);
                 setDatasets(datasetsData['results'] as DatasetStubT[]);
                 setDatasetsCount(datasetsData['count']);
-                setTuples(tuplesData['results'] as TupleT[]);
-                setTuplesCount(tuplesData['count']);
+                setTasks(tasksData['results'] as TaskT[]);
+                setTasksCount(tasksData['count']);
                 setLoading(false);
             } catch (error) {
                 if (
@@ -535,7 +535,7 @@ const OmniSearch = () => {
                         />
                         <ItemGroup
                             title="Tasks"
-                            items={tupleItems}
+                            items={taskItems}
                             getItemProps={getItemProps}
                         />
                     </>

--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -2,10 +2,10 @@ import { Tag, TagLabel, TagLeftIcon, TagProps, Text } from '@chakra-ui/react';
 
 import { getStatusLabel, getStatusStyle } from '@/libs/status';
 import { ComputePlanStatus } from '@/modules/computePlans/ComputePlansTypes';
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 type StatusProps = {
-    status: ComputePlanStatus | TupleStatus;
+    status: ComputePlanStatus | TaskStatus;
     size: TagProps['size'];
     variant?: TagProps['variant'];
     withIcon?: boolean;

--- a/src/components/TableFilters/TaskStatusTableFilter.tsx
+++ b/src/components/TableFilters/TaskStatusTableFilter.tsx
@@ -2,7 +2,7 @@ import useSelection from '@/hooks/useSelection';
 import { useStatus } from '@/hooks/useSyncedState';
 import { useTableFilterCallbackRefs } from '@/hooks/useTableFilters';
 import { getStatusLabel, getStatusDescription } from '@/libs/status';
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 import TableFilterCheckboxes from './TableFilterCheckboxes';
 
@@ -31,7 +31,7 @@ const TaskStatusTableFilter = (): JSX.Element => {
         setTmpStatus(activeStatus);
     };
 
-    const options = Object.values(TupleStatus).map((status) => ({
+    const options = Object.values(TaskStatus).map((status) => ({
         value: status,
         label: getStatusLabel(status),
         description: getStatusDescription(status),

--- a/src/components/TasksTable.tsx
+++ b/src/components/TasksTable.tsx
@@ -38,7 +38,7 @@ import { PaginatedApiResponseT } from '@/modules/common/CommonTypes';
 import { RetrieveComputePlanTasksArgsProps } from '@/modules/computePlans/ComputePlansSlice';
 import { ComputePlanT } from '@/modules/computePlans/ComputePlansTypes';
 import { ListTasksProps } from '@/modules/tasks/TasksSlice';
-import { TupleT, TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskT, TaskStatus } from '@/modules/tasks/TasksTypes';
 import { compilePath, PATHS } from '@/paths';
 
 import { AssetsTable } from '@/components/AssetsTable';
@@ -70,11 +70,11 @@ import Timing from '@/components/Timing';
 type TasksTableProps = {
     loading: boolean;
     list: () => AsyncThunkAction<
-        PaginatedApiResponseT<TupleT>,
+        PaginatedApiResponseT<TaskT>,
         RetrieveComputePlanTasksArgsProps | ListTasksProps,
         { rejectValue: string }
     >;
-    tasks: TupleT[];
+    tasks: TaskT[];
     count: number;
     computePlan?: ComputePlanT | null;
     tableProps?: TableProps;
@@ -125,7 +125,7 @@ const TasksTable = ({
         durationMax,
     ]);
 
-    const context = useTableFiltersContext('tuple');
+    const context = useTableFiltersContext('task');
     const { onPopoverOpen } = context;
 
     return (
@@ -281,7 +281,7 @@ const TasksTable = ({
                                             <Skeleton>
                                                 <Status
                                                     size="sm"
-                                                    status={TupleStatus.done}
+                                                    status={TaskStatus.done}
                                                     withIcon={false}
                                                 />
                                             </Skeleton>
@@ -326,7 +326,7 @@ const TasksTable = ({
                                 {!loading && tasks.length === 0 && (
                                     <EmptyTr
                                         nbColumns={computePlan ? 3 : 4}
-                                        asset="tuple"
+                                        asset="task"
                                     />
                                 )}
                                 {!loading &&

--- a/src/components/Timing.tsx
+++ b/src/components/Timing.tsx
@@ -5,10 +5,10 @@ import {
     ComputePlanStatus,
     ComputePlanT,
 } from '@/modules/computePlans/ComputePlansTypes';
-import { TupleT, TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskT, TaskStatus } from '@/modules/tasks/TasksTypes';
 
 type TimingProps = {
-    asset: ComputePlanT | TupleT;
+    asset: ComputePlanT | TaskT;
 };
 
 const Timing = ({ asset }: TimingProps): JSX.Element => {
@@ -18,8 +18,8 @@ const Timing = ({ asset }: TimingProps): JSX.Element => {
                 {[
                     ComputePlanStatus.todo,
                     ComputePlanStatus.waiting,
-                    TupleStatus.todo,
-                    TupleStatus.waiting,
+                    TaskStatus.todo,
+                    TaskStatus.waiting,
                 ].includes(asset.status)
                     ? 'Not started yet'
                     : 'Information not available'}
@@ -39,9 +39,9 @@ const Timing = ({ asset }: TimingProps): JSX.Element => {
                         ComputePlanStatus.done,
                         ComputePlanStatus.canceled,
                         ComputePlanStatus.failed,
-                        TupleStatus.done,
-                        TupleStatus.canceled,
-                        TupleStatus.failed,
+                        TaskStatus.done,
+                        TaskStatus.canceled,
+                        TaskStatus.failed,
                     ].includes(asset.status)
                         ? 'Information not available'
                         : 'Not ended yet'}

--- a/src/hooks/useDownloadPerfCsv.ts
+++ b/src/hooks/useDownloadPerfCsv.ts
@@ -15,10 +15,10 @@ enum CSV_COLUMN_ID {
     computePlanEndDate = 'computePlanEndDate',
     computePlanMetadata = 'computePlanMetadata',
     worker = 'worker',
-    testtupleKey = 'testtupleKey',
+    testTaskKey = 'testTaskKey',
     metricName = 'metricName',
     lineId = 'lineId',
-    testtupleRank = 'testtupleRank',
+    testTaskRank = 'testTaskRank',
     perf = 'perf',
 }
 
@@ -42,10 +42,10 @@ const CSV_COLUMNS = [
         id: CSV_COLUMN_ID.computePlanMetadata,
     },
     { displayName: 'Worker', id: CSV_COLUMN_ID.worker },
-    { displayName: 'Testtuple key', id: CSV_COLUMN_ID.testtupleKey },
+    { displayName: 'Test task key', id: CSV_COLUMN_ID.testTaskKey },
     { displayName: 'Metric name', id: CSV_COLUMN_ID.metricName },
     { displayName: 'Line ID', id: CSV_COLUMN_ID.lineId },
-    { displayName: 'Testtuple rank', id: CSV_COLUMN_ID.testtupleRank },
+    { displayName: 'Test task rank', id: CSV_COLUMN_ID.testTaskRank },
     { displayName: 'Performance', id: CSV_COLUMN_ID.perf },
 ];
 
@@ -72,12 +72,12 @@ const getDatas = (
                     JSON.stringify(computePlan?.metadata || {})
                 ),
                 worker: escape(serie.worker),
-                testtupleKey: escape(point.testTaskKey || 'NA'),
+                testTaskKey: escape(point.testTaskKey || 'NA'),
                 metricName: escape(serie.metricName),
                 lineId: escape(
                     `#${getSerieIndex(serie.computePlanKey, serie.id)}`
                 ),
-                testtupleRank: escape(point.rank.toString()),
+                testTaskRank: escape(point.rank.toString()),
                 perf: escape(
                     point.perf === null ? 'NA' : point.perf.toString()
                 ),
@@ -111,8 +111,8 @@ const compareDatas = (a: DataT, b: DataT) => {
         return 1;
     }
 
-    const rankA = parseInt(a.testtupleRank);
-    const rankB = parseInt(b.testtupleRank);
+    const rankA = parseInt(a.testTaskRank);
+    const rankB = parseInt(b.testTaskRank);
     if (rankA < rankB) {
         return -1;
     } else if (rankA > rankB) {

--- a/src/libs/status.ts
+++ b/src/libs/status.ts
@@ -14,10 +14,10 @@ import {
     statusDescriptionByComputePlanStatus,
 } from '@/modules/computePlans/ComputePlansTypes';
 import {
-    statusDescriptionByTupleStatus,
-    TupleStatus,
-    TupleStatusDescription,
-} from '@/modules/tasks/TuplesTypes';
+    statusDescriptionByTaskStatus,
+    TaskStatus,
+    TaskStatusDescription,
+} from '@/modules/tasks/TasksTypes';
 
 enum ComputePlanStatusLabel {
     canceled = 'Canceled',
@@ -29,7 +29,7 @@ enum ComputePlanStatusLabel {
     empty = 'Empty',
 }
 
-enum TupleStatusLabel {
+enum TaskStatusLabel {
     canceled = 'Canceled',
     doing = 'Doing',
     done = 'Done',
@@ -38,13 +38,13 @@ enum TupleStatusLabel {
     waiting = 'Waiting',
 }
 
-const statusLabelByTupleStatus: Record<TupleStatus, TupleStatusLabel> = {
-    [TupleStatus.canceled]: TupleStatusLabel.canceled,
-    [TupleStatus.doing]: TupleStatusLabel.doing,
-    [TupleStatus.done]: TupleStatusLabel.done,
-    [TupleStatus.failed]: TupleStatusLabel.failed,
-    [TupleStatus.todo]: TupleStatusLabel.todo,
-    [TupleStatus.waiting]: TupleStatusLabel.waiting,
+const statusLabelByTaskStatus: Record<TaskStatus, TaskStatusLabel> = {
+    [TaskStatus.canceled]: TaskStatusLabel.canceled,
+    [TaskStatus.doing]: TaskStatusLabel.doing,
+    [TaskStatus.done]: TaskStatusLabel.done,
+    [TaskStatus.failed]: TaskStatusLabel.failed,
+    [TaskStatus.todo]: TaskStatusLabel.todo,
+    [TaskStatus.waiting]: TaskStatusLabel.waiting,
 };
 
 const statusLabelByComputePlanStatus: Record<
@@ -61,10 +61,10 @@ const statusLabelByComputePlanStatus: Record<
 };
 
 export const getStatusLabel = (
-    status: TupleStatus | ComputePlanStatus
-): TupleStatusLabel | ComputePlanStatusLabel | string => {
-    if (Object.values(TupleStatus).includes(status as TupleStatus)) {
-        return statusLabelByTupleStatus[status as TupleStatus];
+    status: TaskStatus | ComputePlanStatus
+): TaskStatusLabel | ComputePlanStatusLabel | string => {
+    if (Object.values(TaskStatus).includes(status as TaskStatus)) {
+        return statusLabelByTaskStatus[status as TaskStatus];
     }
     if (
         Object.values(ComputePlanStatus).includes(status as ComputePlanStatus)
@@ -76,10 +76,10 @@ export const getStatusLabel = (
 };
 
 export const getStatusDescription = (
-    status: TupleStatus | ComputePlanStatus
-): TupleStatusDescription | ComputePlanStatusDescription => {
-    if (Object.values(TupleStatus).includes(status as TupleStatus)) {
-        return statusDescriptionByTupleStatus[status as TupleStatus];
+    status: TaskStatus | ComputePlanStatus
+): TaskStatusDescription | ComputePlanStatusDescription => {
+    if (Object.values(TaskStatus).includes(status as TaskStatus)) {
+        return statusDescriptionByTaskStatus[status as TaskStatus];
     }
 
     if (
@@ -103,10 +103,10 @@ type StatusStyleProps = {
 };
 
 export const getStatusStyle = (
-    status: TupleStatus | ComputePlanStatus
+    status: TaskStatus | ComputePlanStatus
 ): StatusStyleProps => {
     switch (status) {
-        case TupleStatus.canceled:
+        case TaskStatus.canceled:
         case ComputePlanStatus.canceled:
             return {
                 icon: RiIndeterminateCircleLine,
@@ -117,9 +117,9 @@ export const getStatusStyle = (
                 progressColor: 'gray.500',
             };
 
-        case TupleStatus.waiting:
+        case TaskStatus.waiting:
         case ComputePlanStatus.waiting:
-        case TupleStatus.todo:
+        case TaskStatus.todo:
         case ComputePlanStatus.todo:
             return {
                 icon: RiTimeLine,
@@ -129,7 +129,7 @@ export const getStatusStyle = (
                 tagSolidBackgroundColor: 'gray.300',
                 progressColor: 'gray.300',
             };
-        case TupleStatus.doing:
+        case TaskStatus.doing:
         case ComputePlanStatus.doing:
             return {
                 icon: RiPlayMiniLine,
@@ -139,7 +139,7 @@ export const getStatusStyle = (
                 tagSolidBackgroundColor: 'blue.500',
                 progressColor: 'blue.500',
             };
-        case TupleStatus.failed:
+        case TaskStatus.failed:
         case ComputePlanStatus.failed:
             return {
                 icon: RiAlertLine,
@@ -149,7 +149,7 @@ export const getStatusStyle = (
                 tagSolidBackgroundColor: 'red.500',
                 progressColor: 'red.500',
             };
-        case TupleStatus.done:
+        case TaskStatus.done:
         case ComputePlanStatus.done:
             return {
                 icon: RiCheckLine,

--- a/src/modules/common/CommonTypes.ts
+++ b/src/modules/common/CommonTypes.ts
@@ -8,14 +8,7 @@ export type PermissionsT = {
     download: PermissionT;
 };
 
-export type AssetT =
-    | 'dataset'
-    | 'algo'
-    | 'composite_algo'
-    | 'aggregate_algo'
-    | 'tuple'
-    | 'compute_plan'
-    | 'user';
+export type AssetT = 'dataset' | 'algo' | 'task' | 'compute_plan' | 'user';
 
 export type PaginatedApiResponseT<T> = {
     count: number;

--- a/src/modules/common/CommonUtils.ts
+++ b/src/modules/common/CommonUtils.ts
@@ -7,9 +7,7 @@ import { AssetT, PaginatedApiResponseT } from './CommonTypes';
 const ASSET_LABEL: Record<AssetT, string> = {
     algo: 'algorithm',
     dataset: 'dataset',
-    composite_algo: 'algorithm',
-    aggregate_algo: 'algorithm',
-    tuple: 'task',
+    task: 'task',
     compute_plan: 'compute plan',
     user: 'user',
 };

--- a/src/modules/computePlans/ComputePlanUtils.ts
+++ b/src/modules/computePlans/ComputePlanUtils.ts
@@ -1,22 +1,22 @@
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 import { ComputePlanT } from './ComputePlansTypes';
 
 export const getStatusCount = (
     computePlan: ComputePlanT,
-    status: TupleStatus
+    status: TaskStatus
 ): number => {
-    if (status === TupleStatus.doing) {
+    if (status === TaskStatus.doing) {
         return computePlan.doing_count;
-    } else if (status === TupleStatus.done) {
+    } else if (status === TaskStatus.done) {
         return computePlan.done_count;
-    } else if (status === TupleStatus.canceled) {
+    } else if (status === TaskStatus.canceled) {
         return computePlan.canceled_count;
-    } else if (status === TupleStatus.failed) {
+    } else if (status === TaskStatus.failed) {
         return computePlan.failed_count;
-    } else if (status === TupleStatus.todo) {
+    } else if (status === TaskStatus.todo) {
         return computePlan.todo_count;
-    } else if (status === TupleStatus.waiting) {
+    } else if (status === TaskStatus.waiting) {
         return computePlan.waiting_count;
     }
 

--- a/src/modules/computePlans/ComputePlansApi.ts
+++ b/src/modules/computePlans/ComputePlansApi.ts
@@ -9,7 +9,7 @@ import {
     ComputePlanStatisticsT,
     PerformanceT,
 } from '@/modules/perf/PerformancesTypes';
-import { TupleT } from '@/modules/tasks/TuplesTypes';
+import { TaskT } from '@/modules/tasks/TasksTypes';
 
 import { ComputePlanStubT, ComputePlanT } from './ComputePlansTypes';
 
@@ -17,7 +17,7 @@ const URLS = {
     LIST: '/compute_plan/',
     RETRIEVE: '/compute_plan/__KEY__/',
     CANCEL: '/compute_plan/__KEY__/cancel/',
-    LIST_TUPLES: '/compute_plan/__KEY__/task/',
+    LIST_TASKS: '/compute_plan/__KEY__/task/',
     LIST_PERFORMANCES: '/compute_plan/__KEY__/perf/',
     EXPORT_PERFORMANCES: '/performance/export/',
 };
@@ -46,15 +46,15 @@ export const cancelComputePlan = (
 ): AxiosPromise<ComputePlanT> =>
     API.post(URLS.CANCEL.replace('__KEY__', key), config);
 
-type APIListCPTuplesArgsProps = APIListArgsT & {
+type APIListCPTasksArgsProps = APIListArgsT & {
     key: string;
 };
 
-export const listComputePlanTuples = (
-    { key, ...apiListArgs }: APIListCPTuplesArgsProps,
+export const listComputePlanTasks = (
+    { key, ...apiListArgs }: APIListCPTasksArgsProps,
     config: AxiosRequestConfig
-): AxiosPromise<PaginatedApiResponseT<TupleT>> => {
-    return API.authenticatedGet(URLS.LIST_TUPLES.replace('__KEY__', key), {
+): AxiosPromise<PaginatedApiResponseT<TaskT>> => {
+    return API.authenticatedGet(URLS.LIST_TASKS.replace('__KEY__', key), {
         ...getApiOptions(apiListArgs),
         ...config,
     });
@@ -64,7 +64,7 @@ type PaginatedPerformanceResponseT = PaginatedApiResponseT<PerformanceT> & {
     compute_plan_statistics: ComputePlanStatisticsT;
 };
 export const listComputePlanPerformances = (
-    { key, ...apiListArgs }: APIListCPTuplesArgsProps,
+    { key, ...apiListArgs }: APIListCPTasksArgsProps,
     config: AxiosRequestConfig
 ): AxiosPromise<PaginatedPerformanceResponseT> => {
     return API.authenticatedGet(

--- a/src/modules/computePlans/ComputePlansSlice.ts
+++ b/src/modules/computePlans/ComputePlansSlice.ts
@@ -8,7 +8,7 @@ import {
     ComputePlanStubT,
     ComputePlanT,
 } from '@/modules/computePlans/ComputePlansTypes';
-import { TupleT } from '@/modules/tasks/TuplesTypes';
+import { TaskT } from '@/modules/tasks/TasksTypes';
 
 type ComputePlansStateT = {
     computePlans: ComputePlanStubT[];
@@ -21,7 +21,7 @@ type ComputePlansStateT = {
     computePlanError: string;
     computePlanUpdating: boolean;
     computePlanUpdateError: string;
-    computePlanTasks: TupleT[];
+    computePlanTasks: TaskT[];
     computePlanTasksCount: number;
     computePlanTasksLoading: boolean;
     computePlanTasksError: string;
@@ -100,12 +100,12 @@ export type RetrieveComputePlanTasksArgsProps = {
 };
 
 export const retrieveComputePlanTasks = createAsyncThunk<
-    PaginatedApiResponseT<TupleT>,
+    PaginatedApiResponseT<TaskT>,
     RetrieveComputePlanTasksArgsProps,
     { rejectValue: string }
 >('computePlans/getTasks', async ({ computePlanKey, ...params }, thunkAPI) => {
     try {
-        const response = await ComputePlansApi.listComputePlanTuples(
+        const response = await ComputePlansApi.listComputePlanTasks(
             {
                 key: computePlanKey,
                 ...params,

--- a/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
+++ b/src/modules/cpWorkflow/CPWorkflowLayout.spec.ts
@@ -1,5 +1,5 @@
 import { computeLayout } from '@/modules/cpWorkflow/CPWorkflowLayout';
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 import { LayoutedTaskGraphT, TaskGraphT } from './CPWorkflowTypes';
 
@@ -14,7 +14,7 @@ const twoTasksGraph: TaskGraphT = {
             key: 'a',
             rank: 0,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs: [],
             outputs: [{ id: 'out_model', kind: 'model' }],
         },
@@ -22,7 +22,7 @@ const twoTasksGraph: TaskGraphT = {
             key: 'b',
             rank: 1,
             worker: 'pharma2',
-            status: TupleStatus.failed,
+            status: TaskStatus.failed,
             inputs: [{ id: 'in_model', kind: 'model' }],
             outputs: [],
         },
@@ -57,14 +57,14 @@ const twoTasksLayoutedGraph: LayoutedTaskGraphT = {
     edges: twoTasksGraph.edges,
 };
 
-const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
+const twoTasksPlusPredictAndTestTaskGraph: TaskGraphT = {
     tasks: [
         ...twoTasksGraph.tasks,
         {
             key: 'predict_a',
             rank: 1,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs: [{ id: 'in_model', kind: 'model' }],
             outputs: [{ id: 'out_model', kind: 'model' }],
         },
@@ -72,7 +72,7 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
             key: 'test_a',
             rank: 2,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs: [{ id: 'in_model', kind: 'model' }],
             outputs: [{ id: 'perf', kind: 'performance' }],
         },
@@ -94,38 +94,38 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
     ],
 };
 
-const twoTasksPlusPredictAndTestTupleLayoutedGraph: LayoutedTaskGraphT = {
+const twoTasksPlusPredictAndTestTaskLayoutedGraph: LayoutedTaskGraphT = {
     tasks: [
         {
-            ...twoTasksPlusPredictAndTestTupleGraph.tasks[0],
+            ...twoTasksPlusPredictAndTestTaskGraph.tasks[0],
             position: {
                 x: 0, // 0 ("in first column")
                 y: 0, // 0 ("first task in the row")
             },
         },
         {
-            ...twoTasksPlusPredictAndTestTupleGraph.tasks[1],
+            ...twoTasksPlusPredictAndTestTaskGraph.tasks[1],
             position: {
                 x: 400, // 1 * CELL_WIDTH ("task in second column")
                 y: 548, // 3 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("3 tasks in first row = first row height") + ROW_BOTTOM_MARGIN + 0 ("first task in the row") + 8 ("uneven column top padding")
             },
         },
         {
-            ...twoTasksPlusPredictAndTestTupleGraph.tasks[2],
+            ...twoTasksPlusPredictAndTestTaskGraph.tasks[2],
             position: {
                 x: 30, // 0 ("in first column") + PREDICT_TASK_LEFT_PADDING
                 y: 170, // 1 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("second task in the row")
             },
         },
         {
-            ...twoTasksPlusPredictAndTestTupleGraph.tasks[3],
+            ...twoTasksPlusPredictAndTestTaskGraph.tasks[3],
             position: {
                 x: 60, // 0 ("in first column") + PREDICT_TASK_LEFT_PADDING
                 y: 340, // 2 * (NODE_HEIGHT+NODE_BOTTOM_MARGIN) ("thirsd task in the row")
             },
         },
     ],
-    edges: twoTasksPlusPredictAndTestTupleGraph.edges,
+    edges: twoTasksPlusPredictAndTestTaskGraph.edges,
 };
 
 const compositeAndAggregateGraph: TaskGraphT = {
@@ -134,7 +134,7 @@ const compositeAndAggregateGraph: TaskGraphT = {
             key: 'composite_a',
             rank: 0,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs: [],
             outputs: [
                 { id: 'out_head_model', kind: 'model' },
@@ -145,7 +145,7 @@ const compositeAndAggregateGraph: TaskGraphT = {
             key: 'aggregate_a',
             rank: 1,
             worker: 'pharma1',
-            status: TupleStatus.failed,
+            status: TaskStatus.failed,
             inputs: [{ id: 'in_models', kind: 'model' }],
             outputs: [{ id: 'out_model', kind: 'model' }],
         },
@@ -153,7 +153,7 @@ const compositeAndAggregateGraph: TaskGraphT = {
             key: 'composite_b',
             rank: 2,
             worker: 'pharma1',
-            status: TupleStatus.done,
+            status: TaskStatus.done,
             inputs: [
                 { id: 'in_head_model', kind: 'model' },
                 { id: 'in_trunk_model', kind: 'model' },
@@ -213,8 +213,8 @@ const compositeAndAggregateLAyoutedGraph: LayoutedTaskGraphT = {
 test('computeLayout', () => {
     expect(computeLayout(emptyGraph)).toStrictEqual(emptyGraph);
     expect(computeLayout(twoTasksGraph)).toStrictEqual(twoTasksLayoutedGraph);
-    expect(computeLayout(twoTasksPlusPredictAndTestTupleGraph)).toStrictEqual(
-        twoTasksPlusPredictAndTestTupleLayoutedGraph
+    expect(computeLayout(twoTasksPlusPredictAndTestTaskGraph)).toStrictEqual(
+        twoTasksPlusPredictAndTestTaskLayoutedGraph
     );
     expect(computeLayout(compositeAndAggregateGraph)).toStrictEqual(
         compositeAndAggregateLAyoutedGraph

--- a/src/modules/cpWorkflow/CPWorkflowTypes.ts
+++ b/src/modules/cpWorkflow/CPWorkflowTypes.ts
@@ -1,4 +1,4 @@
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 type PositionT = {
     x: number;
@@ -10,16 +10,16 @@ type PlugT = {
     kind: string;
 };
 
-export type TaskT = {
+export type WorkflowTaskT = {
     key: string;
     rank: number;
     worker: string;
-    status: TupleStatus;
+    status: TaskStatus;
     inputs: PlugT[];
     outputs: PlugT[];
 };
 
-export type PositionedTaskT = TaskT & {
+export type PositionedWorkflowTaskT = WorkflowTaskT & {
     position: PositionT;
 };
 
@@ -31,11 +31,11 @@ type EdgeT = {
 };
 
 export type TaskGraphT = {
-    tasks: TaskT[];
+    tasks: WorkflowTaskT[];
     edges: EdgeT[];
 };
 
 export type LayoutedTaskGraphT = {
-    tasks: PositionedTaskT[];
+    tasks: PositionedWorkflowTaskT[];
     edges: EdgeT[];
 };

--- a/src/modules/cpWorkflow/CPWorkflowUtils.ts
+++ b/src/modules/cpWorkflow/CPWorkflowUtils.ts
@@ -2,57 +2,59 @@ import { Edge, Node, MarkerType } from 'react-flow-renderer';
 
 import {
     LayoutedTaskGraphT,
-    PositionedTaskT,
+    PositionedWorkflowTaskT,
 } from '@/modules/cpWorkflow/CPWorkflowTypes';
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 import { NODE_WIDTH } from './CPWorkflowLayout';
 
 export const MAX_ZOOM_LEVEL = 1;
 export const MIN_ZOOM_LEVEL = 0.05;
 
-export const NODE_BORDER_COLOR: Record<TupleStatus, string> = {
-    [TupleStatus.failed]: '#F31B61',
-    [TupleStatus.waiting]: '#ADADAD',
-    [TupleStatus.done]: '#2F9797',
-    [TupleStatus.todo]: '#ADADAD',
-    [TupleStatus.doing]: '#0084DC',
-    [TupleStatus.canceled]: '#545454',
+export const NODE_BORDER_COLOR: Record<TaskStatus, string> = {
+    [TaskStatus.failed]: '#F31B61',
+    [TaskStatus.waiting]: '#ADADAD',
+    [TaskStatus.done]: '#2F9797',
+    [TaskStatus.todo]: '#ADADAD',
+    [TaskStatus.doing]: '#0084DC',
+    [TaskStatus.canceled]: '#545454',
 };
 
-export const NODE_LABEL_COLOR: Record<TupleStatus, string> = {
-    [TupleStatus.failed]: '#CB1C51',
-    [TupleStatus.waiting]: '#7F7F7F',
-    [TupleStatus.done]: '#2D7A7A',
-    [TupleStatus.todo]: '#7F7F7F',
-    [TupleStatus.doing]: '#006EBD',
-    [TupleStatus.canceled]: '#373737',
+export const NODE_LABEL_COLOR: Record<TaskStatus, string> = {
+    [TaskStatus.failed]: '#CB1C51',
+    [TaskStatus.waiting]: '#7F7F7F',
+    [TaskStatus.done]: '#2D7A7A',
+    [TaskStatus.todo]: '#7F7F7F',
+    [TaskStatus.doing]: '#006EBD',
+    [TaskStatus.canceled]: '#373737',
 };
 
 export default function makeReactFlowGraph(graphItems: LayoutedTaskGraphT): {
-    nodes: Node<PositionedTaskT>[];
+    nodes: Node<PositionedWorkflowTaskT>[];
     edges: Edge[];
 } {
-    const nodes = graphItems.tasks.map((task): Node<PositionedTaskT> => {
-        return {
-            id: task.key,
-            type: 'taskNode',
-            position: {
-                x: task.position.x,
-                y: task.position.y,
-            },
-            data: task,
-            style: {
-                borderRadius: '4px',
-                zIndex: '3',
-                width: NODE_WIDTH,
-                border: `2px solid ${NODE_BORDER_COLOR[task.status]}`,
-                color: NODE_LABEL_COLOR[task.status],
-                background: 'white',
-                cursor: 'pointer',
-            },
-        };
-    });
+    const nodes = graphItems.tasks.map(
+        (task): Node<PositionedWorkflowTaskT> => {
+            return {
+                id: task.key,
+                type: 'taskNode',
+                position: {
+                    x: task.position.x,
+                    y: task.position.y,
+                },
+                data: task,
+                style: {
+                    borderRadius: '4px',
+                    zIndex: '3',
+                    width: NODE_WIDTH,
+                    border: `2px solid ${NODE_BORDER_COLOR[task.status]}`,
+                    color: NODE_LABEL_COLOR[task.status],
+                    background: 'white',
+                    cursor: 'pointer',
+                },
+            };
+        }
+    );
 
     const edges: Edge[] = graphItems.edges.map((edge) => {
         return {

--- a/src/modules/tasks/TasksApi.ts
+++ b/src/modules/tasks/TasksApi.ts
@@ -6,7 +6,7 @@ import {
     PaginatedApiResponseT,
 } from '@/modules/common/CommonTypes';
 
-import { TupleT } from './TuplesTypes';
+import { TaskT } from './TasksTypes';
 
 export const URLS = {
     LIST: '/task/',
@@ -14,19 +14,19 @@ export const URLS = {
     LOGS_RETRIEVE: '/logs/__KEY__/file/',
 };
 
-export const listTuples = (
+export const listTasks = (
     apiListArgs: APIListArgsT,
     config: AxiosRequestConfig
-): AxiosPromise<PaginatedApiResponseT<TupleT>> =>
+): AxiosPromise<PaginatedApiResponseT<TaskT>> =>
     API.authenticatedGet(URLS.LIST, {
         ...getApiOptions(apiListArgs),
         ...config,
     });
 
-export const retrieveTuple = (
+export const retrieveTask = (
     key: string,
     config: AxiosRequestConfig
-): AxiosPromise<TupleT> =>
+): AxiosPromise<TaskT> =>
     API.authenticatedGet(URLS.RETRIEVE.replace('__KEY__', key), config);
 
 export const retrieveLogs = (

--- a/src/modules/tasks/TasksSlice.ts
+++ b/src/modules/tasks/TasksSlice.ts
@@ -4,15 +4,15 @@ import { AxiosError } from 'axios';
 import { PaginatedApiResponseT } from '@/modules/common/CommonTypes';
 
 import * as TasksApi from './TasksApi';
-import { TupleT } from './TuplesTypes';
+import { TaskT } from './TasksTypes';
 
 type TasksStateT = {
-    tasks: TupleT[];
+    tasks: TaskT[];
     tasksCount: number;
     tasksLoading: boolean;
     tasksError: string;
 
-    task: TupleT | null;
+    task: TaskT | null;
     taskLoading: boolean;
     taskError: string;
 
@@ -45,12 +45,12 @@ export type ListTasksProps = {
 };
 
 export const listTasks = createAsyncThunk<
-    PaginatedApiResponseT<TupleT>,
+    PaginatedApiResponseT<TaskT>,
     ListTasksProps,
     { rejectValue: string }
 >('tasks/listTasks', async (params: ListTasksProps, thunkAPI) => {
     try {
-        const response = await TasksApi.listTuples(params, {
+        const response = await TasksApi.listTasks(params, {
             signal: thunkAPI.signal,
         });
         return response.data;
@@ -64,12 +64,12 @@ export const listTasks = createAsyncThunk<
 });
 
 export const retrieveTask = createAsyncThunk<
-    TupleT,
+    TaskT,
     string,
     { rejectValue: string }
 >('tasks/get', async (key: string, thunkAPI) => {
     try {
-        const response = await TasksApi.retrieveTuple(key, {
+        const response = await TasksApi.retrieveTask(key, {
             signal: thunkAPI.signal,
         });
         return response.data;

--- a/src/modules/tasks/TasksTypes.ts
+++ b/src/modules/tasks/TasksTypes.ts
@@ -6,7 +6,7 @@ import {
     PermissionT,
 } from '@/modules/common/CommonTypes';
 
-export enum TupleStatus {
+export enum TaskStatus {
     waiting = 'STATUS_WAITING',
     todo = 'STATUS_TODO',
     doing = 'STATUS_DOING',
@@ -15,7 +15,7 @@ export enum TupleStatus {
     failed = 'STATUS_FAILED',
 }
 
-export enum TupleStatusDescription {
+export enum TaskStatusDescription {
     waiting = 'Task is waiting for parent tasks to end',
     todo = 'Task is ready and waiting for available space to run',
     doing = 'Task is processing',
@@ -30,16 +30,16 @@ export enum ErrorT {
     internal = 'INTERNAL_ERROR',
 }
 
-export const statusDescriptionByTupleStatus: Record<
-    TupleStatus,
-    TupleStatusDescription
+export const statusDescriptionByTaskStatus: Record<
+    TaskStatus,
+    TaskStatusDescription
 > = {
-    [TupleStatus.waiting]: TupleStatusDescription.waiting,
-    [TupleStatus.todo]: TupleStatusDescription.todo,
-    [TupleStatus.doing]: TupleStatusDescription.doing,
-    [TupleStatus.done]: TupleStatusDescription.done,
-    [TupleStatus.canceled]: TupleStatusDescription.canceled,
-    [TupleStatus.failed]: TupleStatusDescription.failed,
+    [TaskStatus.waiting]: TaskStatusDescription.waiting,
+    [TaskStatus.todo]: TaskStatusDescription.todo,
+    [TaskStatus.doing]: TaskStatusDescription.doing,
+    [TaskStatus.done]: TaskStatusDescription.done,
+    [TaskStatus.canceled]: TaskStatusDescription.canceled,
+    [TaskStatus.failed]: TaskStatusDescription.failed,
 };
 
 export type TaskInputT = {
@@ -51,14 +51,14 @@ export type TaskInputT = {
     parent_task_output_identifier?: string;
 };
 
-export type TupleT = {
+export type TaskT = {
     key: string;
     creation_date: string;
     algo: AlgoT;
     compute_plan_key: string;
     owner: string;
     metadata: MetadataT;
-    status: TupleStatus;
+    status: TaskStatus;
     rank: number;
     tag: string;
     parent_task_keys: string[];

--- a/src/routes/computePlanDetails/components/TasksWorkflow.tsx
+++ b/src/routes/computePlanDetails/components/TasksWorkflow.tsx
@@ -17,7 +17,7 @@ import {
     NODE_WIDTH,
     NODE_HEIGHT,
 } from '@/modules/cpWorkflow/CPWorkflowLayout';
-import { PositionedTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
+import { PositionedWorkflowTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
 import makeReactFlowGraph, {
     MIN_ZOOM_LEVEL,
     MAX_ZOOM_LEVEL,
@@ -55,7 +55,10 @@ const TasksWorkflow = (): JSX.Element => {
         setEdges(rfGraph.edges);
     }, [layoutedGraph, setNodes, setEdges]);
 
-    const onNodeClick = (e: React.MouseEvent, node: Node<PositionedTaskT>) => {
+    const onNodeClick = (
+        e: React.MouseEvent,
+        node: Node<PositionedWorkflowTaskT>
+    ) => {
         if (node) {
             setSelectedTaskKey(node.data.key);
         }

--- a/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
+++ b/src/routes/computePlanDetails/components/WorkflowTaskNode.tsx
@@ -4,14 +4,14 @@ import { Handle, Position } from 'react-flow-renderer';
 
 import { Box, Text, Flex } from '@chakra-ui/react';
 
-import { PositionedTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
+import { PositionedWorkflowTaskT } from '@/modules/cpWorkflow/CPWorkflowTypes';
 import {
     NODE_BORDER_COLOR,
     NODE_LABEL_COLOR,
 } from '@/modules/cpWorkflow/CPWorkflowUtils';
 
 type TaskNodeProps = {
-    data: PositionedTaskT;
+    data: PositionedWorkflowTaskT;
 };
 
 const TaskNode = ({ data }: TaskNodeProps) => {

--- a/src/routes/tasks/components/DrawerSectionOutModelEntryContent.tsx
+++ b/src/routes/tasks/components/DrawerSectionOutModelEntryContent.tsx
@@ -3,7 +3,7 @@ import { RiLockLine } from 'react-icons/ri';
 
 import useCanDownloadModel from '@/hooks/useCanDownloadModel';
 import { ModelT } from '@/modules/tasks/ModelsTypes';
-import { TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskStatus } from '@/modules/tasks/TasksTypes';
 
 import DownloadIconButton from '@/components/DownloadIconButton';
 
@@ -12,27 +12,27 @@ const DrawerSectionOutModelEntryContent = ({
     taskStatus,
 }: {
     model: ModelT | null;
-    taskStatus: TupleStatus;
+    taskStatus: TaskStatus;
 }): JSX.Element | null => {
     const canDownloadModel = useCanDownloadModel();
 
     let content = null;
 
-    if (taskStatus === TupleStatus.waiting) {
+    if (taskStatus === TaskStatus.waiting) {
         content = (
             <Text color="gray.500">Model training hasn't started yet</Text>
         );
-    } else if (taskStatus === TupleStatus.todo) {
+    } else if (taskStatus === TaskStatus.todo) {
         content = (
             <Text color="gray.500">Model training hasn't started yet</Text>
         );
-    } else if (taskStatus === TupleStatus.doing) {
+    } else if (taskStatus === TaskStatus.doing) {
         content = <Text color="gray.500">Model still training</Text>;
-    } else if (taskStatus === TupleStatus.failed) {
+    } else if (taskStatus === TaskStatus.failed) {
         content = <Text color="gray.500">Model training failed</Text>;
-    } else if (taskStatus === TupleStatus.canceled) {
+    } else if (taskStatus === TaskStatus.canceled) {
         content = <Text color="gray.500">Model training canceled</Text>;
-    } else if (taskStatus === TupleStatus.done) {
+    } else if (taskStatus === TaskStatus.done) {
         if (model === null) {
             content = <Text color="gray.500">Model is not available</Text>;
         } else {

--- a/src/routes/tasks/components/ErrorAlert.tsx
+++ b/src/routes/tasks/components/ErrorAlert.tsx
@@ -12,7 +12,7 @@ import {
 import { RiCheckboxCircleLine } from 'react-icons/ri';
 
 import useHasPermission from '@/hooks/useHasPermission';
-import { ErrorT, TupleT } from '@/modules/tasks/TuplesTypes';
+import { ErrorT, TaskT } from '@/modules/tasks/TasksTypes';
 
 import LogsModal from './LogsModal';
 
@@ -32,7 +32,7 @@ const ErrorAlertBase = ({
     </Alert>
 );
 
-const ErrorAlert = ({ task }: { task: TupleT }): JSX.Element | null => {
+const ErrorAlert = ({ task }: { task: TaskT }): JSX.Element | null => {
     const hasPermission = useHasPermission();
     const { isOpen, onOpen, onClose } = useDisclosure();
 

--- a/src/routes/tasks/components/LogsModal.tsx
+++ b/src/routes/tasks/components/LogsModal.tsx
@@ -16,7 +16,7 @@ import useAppDispatch from '@/hooks/useAppDispatch';
 import useAppSelector from '@/hooks/useAppSelector';
 import { URLS } from '@/modules/tasks/TasksApi';
 import { retrieveLogs } from '@/modules/tasks/TasksSlice';
-import { TupleT } from '@/modules/tasks/TuplesTypes';
+import { TaskT } from '@/modules/tasks/TasksTypes';
 
 import CopyIconButton from '@/components/CopyIconButton';
 import DownloadIconButton from '@/components/DownloadIconButton';
@@ -28,7 +28,7 @@ const CodeHighlighter = React.lazy(
 type LogsModalProps = {
     isOpen: boolean;
     onClose: () => void;
-    task: TupleT;
+    task: TaskT;
 };
 const LogsModal = ({ isOpen, onClose, task }: LogsModalProps) => {
     const initialFocusRef = useRef(null);

--- a/src/routes/tasks/components/TaskInputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskInputsDrawerSection.tsx
@@ -14,7 +14,7 @@ import useCanDownloadModel from '@/hooks/useCanDownloadModel';
 import { AssetKindT, InputT } from '@/modules/algos/AlgosTypes';
 import { getAssetKindLabel } from '@/modules/algos/AlgosUtils';
 import { FileT, PermissionsT } from '@/modules/common/CommonTypes';
-import { TaskInputT, TupleT } from '@/modules/tasks/TuplesTypes';
+import { TaskInputT, TaskT } from '@/modules/tasks/TasksTypes';
 import { compilePath, PATHS } from '@/paths';
 
 import DownloadIconButton from '@/components/DownloadIconButton';
@@ -310,7 +310,7 @@ const TaskInputsDrawerSection = ({
     task,
 }: {
     loading: boolean;
-    task: TupleT | null;
+    task: TaskT | null;
 }): JSX.Element => {
     // Fusion algoInputs and task inputs in an object to have the 'multiple' and 'optional' property
     const inputsPerIdentifier: {

--- a/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
@@ -13,33 +13,33 @@ import {
 
 import { getAssetKindLabel } from '@/modules/algos/AlgosUtils';
 import { ModelT } from '@/modules/tasks/ModelsTypes';
-import { TupleT, TupleStatus } from '@/modules/tasks/TuplesTypes';
+import { TaskT, TaskStatus } from '@/modules/tasks/TasksTypes';
 
 import { DrawerSection } from '@/components/DrawerSection';
 
 import DrawerSectionOutModelEntryContent from './DrawerSectionOutModelEntryContent';
 
-const getOutputKind = (task: TupleT, output_id: string) => {
+const getOutputKind = (task: TaskT, output_id: string) => {
     return task.algo.outputs[output_id].kind;
 };
 
-const isMultipleOutput = (task: TupleT, output_id: string) => {
+const isMultipleOutput = (task: TaskT, output_id: string) => {
     return task.algo.outputs[output_id].multiple;
 };
 
-const displayPerformance = (value: number, taskStatus: TupleStatus) => {
+const displayPerformance = (value: number, taskStatus: TaskStatus) => {
     if (value === null) {
         let msg: string;
         if (
-            taskStatus === TupleStatus.waiting ||
-            taskStatus === TupleStatus.todo
+            taskStatus === TaskStatus.waiting ||
+            taskStatus === TaskStatus.todo
         ) {
             msg = "computation hasn't started yet";
-        } else if (taskStatus === TupleStatus.doing) {
+        } else if (taskStatus === TaskStatus.doing) {
             msg = 'computation is ongoing';
-        } else if (taskStatus === TupleStatus.failed) {
+        } else if (taskStatus === TaskStatus.failed) {
             msg = 'computation failed';
-        } else if (taskStatus === TupleStatus.canceled) {
+        } else if (taskStatus === TaskStatus.canceled) {
             msg = 'computation canceled';
         } else {
             msg = 'Value not available';
@@ -50,7 +50,7 @@ const displayPerformance = (value: number, taskStatus: TupleStatus) => {
     }
 };
 
-const displayModel = (value: ModelT | null, taskStatus: TupleStatus) => {
+const displayModel = (value: ModelT | null, taskStatus: TaskStatus) => {
     return (
         <DrawerSectionOutModelEntryContent
             taskStatus={taskStatus}
@@ -64,7 +64,7 @@ const TaskOutputsDrawerSection = ({
     task,
 }: {
     loading: boolean;
-    task: TupleT | null;
+    task: TaskT | null;
 }) => {
     return (
         <DrawerSection title="Outputs">


### PR DESCRIPTION
Signed-off-by: Jérémy Morel <jeremy.morel@owkin.com>

## Description

Renames all tuple things into task things. This is pure code maintenance to avoid dragging an old naming in the future.

There was also a couple of aggregate and composite names still there, I removed them as well.