### PR TITLE
fix: last admin check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   UI and markup glitches on login page (#123)
+-   Check for "last admin" when editing a user (#131)
 
 ### Fixed
 

--- a/src/routes/users/components/UserDrawer.tsx
+++ b/src/routes/users/components/UserDrawer.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 
 import { Drawer, useDisclosure, DrawerOverlay } from '@chakra-ui/react';
 
-import useAppDispatch from '@/hooks/useAppDispatch';
 import useKeyFromPath from '@/hooks/useKeyFromPath';
 import { useSetLocationPreserveParams } from '@/hooks/useLocationWithParams';
 import { PATHS } from '@/paths';
@@ -11,18 +10,15 @@ import CreateUserForm from './CreateUserForm';
 import UpdateUserForm from './UpdateUserForm';
 
 const UserDrawer = (): JSX.Element => {
-    const dispatch = useAppDispatch();
     const setLocationPreserveParams = useSetLocationPreserveParams();
     const { isOpen, onOpen, onClose } = useDisclosure();
-    const key = useKeyFromPath(PATHS.USER);
-
-    const editMode = key !== 'create';
+    const username = useKeyFromPath(PATHS.USER);
 
     useEffect(() => {
-        if (key && !isOpen) {
+        if (!!username && !isOpen) {
             onOpen();
         }
-    }, [dispatch, isOpen, onOpen, editMode, key]);
+    }, [isOpen, onOpen, username]);
 
     const closeHandler = () => {
         setLocationPreserveParams(PATHS.USERS);
@@ -38,11 +34,14 @@ const UserDrawer = (): JSX.Element => {
             autoFocus={false}
         >
             <DrawerOverlay />
-            {!editMode && isOpen && (
+            {username === 'create' && (
                 <CreateUserForm closeHandler={closeHandler} />
             )}
-            {editMode && isOpen && (
-                <UpdateUserForm closeHandler={closeHandler} />
+            {!!username && username !== 'create' && (
+                <UpdateUserForm
+                    closeHandler={closeHandler}
+                    username={username || ''}
+                />
             )}
         </Drawer>
     );


### PR DESCRIPTION
Signed-off-by: Jérémy Morel <jeremy.morel@owkin.com>

Fixes https://github.com/Substra/substra-frontend/issues/130

## Description

The check for "last admin" status of the currently edited user had a couple of issues:
1. it was pretty inefficient as it needed to fetch ALL users from the backend, and then check that there is only one admin. I tackled this by adding a filter on role in the backend and then just getting the count on the first page of results for the `/users?role=ADMIN`request. See https://github.com/Substra/substra-backend/pull/517
2. there was a race condition between the multiple useEffects. This is solved by having a single useEffect that both fetches the user to edit and then checks the "is last admin" status before setting loading to false.