### PR TITLE
feat: update cp failed task key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Open task drawer directly in cp details page (#122)
 -   Algo creation events aren't included in newsfeed anymore (#127)
 -   Renamed any tuple thing into a task thing (#129)
+-   Update compute plan failed task key
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+-   Update compute plan failed task key (#134)
+
 ## [0.37.0] - 2022-11-22
 
 ### Added
@@ -17,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Open task drawer directly in cp details page (#122)
 -   Algo creation events aren't included in newsfeed anymore (#127)
 -   Renamed any tuple thing into a task thing (#129)
--   Update compute plan failed task key (#134)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Open task drawer directly in cp details page (#122)
 -   Algo creation events aren't included in newsfeed anymore (#127)
 -   Renamed any tuple thing into a task thing (#129)
--   Update compute plan failed task key
+-   Update compute plan failed task key (#134)
 
 ### Fixed
 

--- a/src/modules/computePlans/ComputePlansTypes.ts
+++ b/src/modules/computePlans/ComputePlansTypes.ts
@@ -53,7 +53,7 @@ export type ComputePlanStubT = {
 };
 
 export type ComputePlanT = ComputePlanStubT & {
-    failed_task?: { key: string };
+    failed_task_key?: string;
 };
 
 export const isComputePlan = (


### PR DESCRIPTION
Signed-off-by: Serge Bouchut <serge.bouchut@owkin.com>

API has changed: we now have a flat field `failed_task_key` (as `failed_task.category` has been removed).
See: https://github.com/Substra/substra-backend/pull/525

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](link here)

## Description

<!--- Describe your choices and changes in detail -->

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

-   Think to update CHANGELOG.md before merge if needed !
