### PR TITLE
Add metric output_identifier to series grouping logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Open task drawer directly in cp details page (#122)
 -   Algo creation events aren't included in newsfeed anymore (#127)
 -   Renamed any tuple thing into a task thing (#129)
+-   Use output_identifier to group series (#145)
 
 ### Fixed
 

--- a/src/modules/perf/PerformancesTypes.ts
+++ b/src/modules/perf/PerformancesTypes.ts
@@ -11,6 +11,7 @@ export type PerformanceT = {
     metric: {
         key: string;
         name: string;
+        output_identifier: string;
     };
     perf: number | null;
 };

--- a/src/modules/series/SeriesTypes.ts
+++ b/src/modules/series/SeriesTypes.ts
@@ -7,6 +7,7 @@ export type SerieFeaturesT = {
     worker: string;
     metricKey: string;
     metricName: string;
+    metricOutputIdentifier: string;
     computePlanKey: string;
 };
 

--- a/src/modules/series/SeriesUtils.ts
+++ b/src/modules/series/SeriesUtils.ts
@@ -27,6 +27,7 @@ function buildSerieFeatures(
         worker: performance.compute_task.worker,
         metricKey: performance.metric.key,
         metricName: performance.metric.name,
+        metricOutputIdentifier: performance.metric.output_identifier,
         computePlanKey,
     };
 }
@@ -37,6 +38,7 @@ function areSeriesEqual(sf1: SerieFeaturesT, sf2: SerieFeaturesT): boolean {
         sf1.datasetKey === sf2.datasetKey &&
         sf1.worker === sf2.worker &&
         sf1.metricKey === sf2.metricKey &&
+        sf1.metricOutputIdentifier === sf2.metricOutputIdentifier &&
         areSetEqual(new Set(sf1.dataSampleKeys), new Set(sf2.dataSampleKeys))
     );
 }
@@ -119,16 +121,24 @@ export function buildSeries(
 export function buildSeriesGroups(series: SerieT[]): SerieT[][] {
     const groups = [];
 
-    const metricNames = new Set(
-        series.map((serie) => serie.metricName.toLowerCase())
+    const seriesGroupings = new Set(
+        series.map((serie) => [
+            serie.algoKey,
+            serie.metricOutputIdentifier.toLowerCase(),
+        ])
     );
-    for (const metricName of metricNames) {
+    for (const seriesGrouping of seriesGroupings) {
+        const [algoKey, metricOutputIdentifier] = seriesGrouping;
         const metricGroup = series.filter(
-            (serie) => serie.metricName.toLowerCase() === metricName
+            (serie) =>
+                serie.algoKey === algoKey &&
+                serie.metricOutputIdentifier.toLowerCase() ===
+                    metricOutputIdentifier
         );
 
         groups.push(metricGroup);
     }
+
     return groups;
 }
 


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1203124674173179/1202721024997173)

## Description

<!--- Describe your choices and changes in detail -->

Use the new output_identifier from compute plan performance endpoint to build series groups to display performance charts
