### PR TITLE
chore: Release 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   UI and markup glitches on login page (#123)
 -   Check for "last admin" when editing a user (#131)
-
-### Fixed
-
 -   Warnings during npm install (#126)
 
 ## [0.36.0] - 2022-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.37.0] - 2022-11-22
 
 ### Added
 

--- a/charts/substra-frontend/CHANGELOG.md
+++ b/charts/substra-frontend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.9
+
+- Upgraded AppVersion to 0.37.0
+
 ## 1.0.8
 
 ### Changed

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -9,6 +9,6 @@ sources:
 
 type: application
 
-version: 1.0.8
-appVersion: 0.36.0 # should be same as in package.json
+version: 1.0.9
+appVersion: 0.37.0 # should be same as in package.json
 kubeVersion: ">= 1.19.0-0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "substra-frontend",
-    "version": "0.36.0",
+    "version": "0.37.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "substra-frontend",
-            "version": "0.36.0",
+            "version": "0.37.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@chakra-ui/react": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "license": "Apache-2.0",
     "private": "true",
-    "version": "0.36.0",
+    "version": "0.37.0",
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

## [0.37.0] - 2022-11-22

### Added

-   Documentation link in user menu (#132)

### Changed

-   Removed task categories from the frontend (#119)
-   Open task drawer directly in cp details page (#122)
-   Algo creation events aren't included in newsfeed anymore (#127)
-   Renamed any tuple thing into a task thing (#129)

### Fixed

-   UI and markup glitches on login page (#123)
-   Check for "last admin" when editing a user (#131)
-   Warnings during npm install (#126)


