### PR TITLE
fix: series grouping & perf details serie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-   Series grouping calcul & metric details page (#xxx)
+
 ## [0.38.0] - 2022-12-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Update compute plan failed task key (#134)
+-   Use output_identifier to group series (#145)
 -   Remove deprecated parent_task_keys from TaskT (#153)
 
 ### Fixed
@@ -28,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Open task drawer directly in cp details page (#122)
 -   Algo creation events aren't included in newsfeed anymore (#127)
 -   Renamed any tuple thing into a task thing (#129)
--   Use output_identifier to group series (#145)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Series grouping calcul & metric details page (#xxx)
+-   Series grouping calcul & metric details page (#152)
 
 ## [0.38.0] - 2022-12-19
 

--- a/src/components/PerfBrowser.tsx
+++ b/src/components/PerfBrowser.tsx
@@ -19,6 +19,8 @@ const PerfBrowser = ({ SidebarComponent }: PerfBrowserProps) => {
         loading,
         selectedMetricName,
         setSelectedMetricName,
+        setSelectedMetricKey,
+        setSelectedMetricOutputIdentifier,
         xAxisMode,
         seriesGroups,
         seriesGroupsWithRounds,
@@ -75,9 +77,17 @@ const PerfBrowser = ({ SidebarComponent }: PerfBrowserProps) => {
                                             ? seriesGroupsWithRounds
                                             : seriesGroups
                                     }
-                                    onCardClick={(metricName) =>
-                                        setSelectedMetricName(metricName)
-                                    }
+                                    onCardClick={(
+                                        metricName,
+                                        metricKey,
+                                        metricOutputIdentifier
+                                    ) => {
+                                        setSelectedMetricName(metricName);
+                                        setSelectedMetricKey(metricKey);
+                                        setSelectedMetricOutputIdentifier(
+                                            metricOutputIdentifier
+                                        );
+                                    }}
                                 />
                             )}
                         </>

--- a/src/components/PerfDetails.tsx
+++ b/src/components/PerfDetails.tsx
@@ -15,10 +15,20 @@ type PerfDetailsProps = {
 };
 
 const PerfDetails = ({ series }: PerfDetailsProps): JSX.Element => {
-    const { perfChartRef, setSelectedMetricName } =
-        useContext(PerfBrowserContext);
+    const {
+        perfChartRef,
+        setSelectedMetricName,
+        setSelectedMetricKey,
+        setSelectedMetricOutputIdentifier,
+    } = useContext(PerfBrowserContext);
 
-    useKeyPress('Escape', () => setSelectedMetricName(''));
+    const resetSelectedMetric = () => {
+        setSelectedMetricName('');
+        setSelectedMetricKey('');
+        setSelectedMetricOutputIdentifier('');
+    };
+
+    useKeyPress('Escape', () => resetSelectedMetric());
 
     return (
         <Flex
@@ -48,7 +58,7 @@ const PerfDetails = ({ series }: PerfDetailsProps): JSX.Element => {
                         backgroundColor="white"
                         leftIcon={<RiArrowLeftLine />}
                         rightIcon={<Kbd backgroundColor="white">Esc</Kbd>}
-                        onClick={() => setSelectedMetricName('')}
+                        onClick={() => resetSelectedMetric()}
                     >
                         Go back
                     </Button>

--- a/src/components/PerfList.tsx
+++ b/src/components/PerfList.tsx
@@ -8,7 +8,11 @@ import PerfEmptyState from '@/components/PerfEmptyState';
 
 type PerfListProps = {
     seriesGroups: SerieT[][];
-    onCardClick: (metricName: string) => void;
+    onCardClick: (
+        metricName: string,
+        metricKey: string,
+        metricOutputIdentifier: string
+    ) => void;
 };
 const PerfList = ({ seriesGroups, onCardClick }: PerfListProps) => {
     return (
@@ -27,7 +31,13 @@ const PerfList = ({ seriesGroups, onCardClick }: PerfListProps) => {
                     <WrapItem key={`${series[0].metricKey}-${series[0].id}`}>
                         <PerfCard
                             title={series[0].metricName}
-                            onClick={() => onCardClick(series[0].metricName)}
+                            onClick={() =>
+                                onCardClick(
+                                    series[0].metricName,
+                                    series[0].metricKey,
+                                    series[0].metricOutputIdentifier
+                                )
+                            }
                         >
                             <PerfChart
                                 series={series}

--- a/src/hooks/usePerfBrowser.ts
+++ b/src/hooks/usePerfBrowser.ts
@@ -66,6 +66,10 @@ type PerfBrowserContextT = {
     // Currently selected metric with its series
     selectedMetricName: string;
     setSelectedMetricName: (name: string) => void;
+    selectedMetricKey: string;
+    setSelectedMetricKey: (name: string) => void;
+    selectedMetricOutputIdentifier: string;
+    setSelectedMetricOutputIdentifier: (name: string) => void;
     selectedSeriesGroup: SerieT[];
     // Serie, compute plan and organization to highlight on charts
     highlightedSerie: HighlightedSerieT | undefined;
@@ -119,6 +123,10 @@ export const PerfBrowserContext = createContext<PerfBrowserContextT>({
         (event: React.ChangeEvent<HTMLInputElement>) => {},
     selectedMetricName: '',
     setSelectedMetricName: (name: string) => {},
+    selectedMetricKey: '',
+    setSelectedMetricKey: (name: string) => {},
+    selectedMetricOutputIdentifier: '',
+    setSelectedMetricOutputIdentifier: (name: string) => {},
     selectedSeriesGroup: [],
     highlightedSerie: undefined,
     setHighlightedSerie: (highlightedSerie) => {},
@@ -159,6 +167,12 @@ const usePerfBrowser = (
         'selectedMetricName',
         ''
     );
+    const [selectedMetricKey, setSelectedMetricKey] = useSyncedStringState(
+        'selectedMetricKey',
+        ''
+    );
+    const [selectedMetricOutputIdentifier, setSelectedMetricOutputIdentifier] =
+        useSyncedStringState('selectedMetricOutputIdentifier', '');
     const [highlightedSerie, setHighlightedSerie] =
         useState<HighlightedSerieT>();
     const [highlightedComputePlanKey, setHighlightedComputePlanKey] =
@@ -224,8 +238,10 @@ const usePerfBrowser = (
 
         const groupsMatchingMetric = seriesGroups.filter(
             (series) =>
-                series[0].metricName.toLowerCase() ===
-                selectedMetricName.toLowerCase()
+                series[0].metricKey.toLowerCase() ===
+                    selectedMetricKey.toLowerCase() &&
+                series[0].metricOutputIdentifier.toLowerCase() ===
+                    selectedMetricOutputIdentifier.toLowerCase()
         );
 
         if (groupsMatchingMetric.length > 0) {
@@ -233,7 +249,12 @@ const usePerfBrowser = (
         } else {
             return [];
         }
-    }, [seriesGroups, selectedMetricName]);
+    }, [
+        seriesGroups,
+        selectedMetricName,
+        selectedMetricKey,
+        selectedMetricOutputIdentifier,
+    ]);
 
     useEffect(() => {
         setSelectedComputePlanKeys(
@@ -427,6 +448,10 @@ const usePerfBrowser = (
             // selected metric
             selectedMetricName,
             setSelectedMetricName,
+            selectedMetricKey,
+            setSelectedMetricKey,
+            selectedMetricOutputIdentifier,
+            setSelectedMetricOutputIdentifier,
             selectedSeriesGroup,
             // event: highlighted serie, compute plan or organization
             highlightedSerie,

--- a/src/modules/series/SeriesUtils.ts
+++ b/src/modules/series/SeriesUtils.ts
@@ -122,13 +122,16 @@ export function buildSeriesGroups(series: SerieT[]): SerieT[][] {
     const groups = [];
 
     const seriesGroupings = new Set(
-        series.map((serie) => [
-            serie.algoKey,
-            serie.metricOutputIdentifier.toLowerCase(),
-        ])
+        series.map((serie) =>
+            JSON.stringify({
+                algoKey: serie.algoKey,
+                metricOutputIdentifier:
+                    serie.metricOutputIdentifier.toLowerCase(),
+            })
+        )
     );
     for (const seriesGrouping of seriesGroupings) {
-        const [algoKey, metricOutputIdentifier] = seriesGrouping;
+        const { algoKey, metricOutputIdentifier } = JSON.parse(seriesGrouping);
         const metricGroup = series.filter(
             (serie) =>
                 serie.algoKey === algoKey &&

--- a/src/modules/series/SeriesUtils.ts
+++ b/src/modules/series/SeriesUtils.ts
@@ -124,17 +124,18 @@ export function buildSeriesGroups(series: SerieT[]): SerieT[][] {
     const seriesGroupings = new Set(
         series.map((serie) =>
             JSON.stringify({
-                algoKey: serie.algoKey,
+                metricKey: serie.metricKey,
                 metricOutputIdentifier:
                     serie.metricOutputIdentifier.toLowerCase(),
             })
         )
     );
     for (const seriesGrouping of seriesGroupings) {
-        const { algoKey, metricOutputIdentifier } = JSON.parse(seriesGrouping);
+        const { metricKey, metricOutputIdentifier } =
+            JSON.parse(seriesGrouping);
         const metricGroup = series.filter(
             (serie) =>
-                serie.algoKey === algoKey &&
+                serie.metricKey === metricKey &&
                 serie.metricOutputIdentifier.toLowerCase() ===
                     metricOutputIdentifier
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1203124674173179/1203588976082680)

## Description

Fix 2 bugs pertaining to the new way of grouping series for the performance page. Before the series where grouped using the metricName, but now they are grouped using the pair metricKey(=algoKey)/metricOutputIdentifier. This introduced 2 bugs : 

- selecting/unselecting CPs in compare page was creating duplicate of performance cards. This was because when passing to the new grouping method we passed from a string (metricName) to an array ([algoKey, metricOutputIdentifier]) and the `Set` object that stocks unique values doesn't handle arrays in the same way. Fixed with stringifying & parsing the pair in the Set instead of using an array.

- with the new method, it is now possible to have several groups with the same metricName, meaning several performance cards in the performance browser. Clicking any card always redirected to the performance details of the first card of a given metricName. Fixed by passing filtered serie to performance details page based on metricKey & metricOutputIdentifier instead of metricName.