### PR TITLE
chore: Remove deprecated parent_task_keys from TaskT

### DIFF
--- a/src/modules/tasks/TasksTypes.ts
+++ b/src/modules/tasks/TasksTypes.ts
@@ -61,7 +61,6 @@ export type TaskT = {
     status: TaskStatus;
     rank: number;
     tag: string;
-    parent_task_keys: string[];
     worker: string;
     start_date?: string;
     end_date?: string;


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Remove deprecated property parent_task_keys from task type
