### PR TITLE
chore: Remove test_only property from datasample type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Get tasks inputs & outputs assets from new endpoints (#144)
 
+### Removed
+
+-   test_only property from datasample type (#158)
+
 ## [0.38.1] - 2022-01-04
 
 ### Fixed

--- a/src/modules/datasets/DatasetsTypes.ts
+++ b/src/modules/datasets/DatasetsTypes.ts
@@ -30,5 +30,4 @@ export type DatasampleT = {
     data_manager_keys: string[];
     key: string;
     owner: string;
-    test_only: boolean;
 };


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1203124674173179/1203074394111393)

## Description

Remove test_only property from datasample type as it now deprecated and being removed from all repositories.
