### PR TITLE
chore: change url displayed by vite in local

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,6 @@ export default defineConfig({
     },
     server: {
         port: 3000,
-        host: '127.0.0.1',
+        host: 'substra-frontend.org-1.com',
     },
 });


### PR DESCRIPTION
Signed-off-by: SdgJlbl <sarah.diot-girard@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

<!--- Describe your choices and changes in detail -->

When launching the frontend locally, either using `npm run dev` or the provided Dockerfile, `vite` displays a clickable url which points to `http://127.0.0.1:3000/`. Yet, the frontend can be accessed locally at `http://substra-frontend.org-1.com:3000`.  

The provided change allows for the displayed url to match what should be accessed. 

## How to test

<!--- Provide some help tips to the technical reviewer -->

I am unsure if this change could be impacting other parts of the frontend application, due to my inexperience with the codebase.


## Notes for developers and reviewers:

-   Think to update CHANGELOG.md before merge if needed !
