### PR TITLE
chore: Release 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.39.0] - 2022-01-31
+
 ### Added
 
 -   CP creators are available data (#124)
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Get tasks inputs & outputs assets from new endpoints (#144)
+-   Change url displayed by vite in local (#163)
 
 ### Removed
 

--- a/charts/substra-frontend/CHANGELOG.md
+++ b/charts/substra-frontend/CHANGELOG.md
@@ -1,70 +1,82 @@
 # Changelog
 
+## 1.0.13
+
+### Changed
+
+-   Upgraded AppVersion to 0.39.0
+
+## 1.0.12
+
+### Changed
+
+-   Update chart maintainers
+
 ## 1.0.11
 
 ### Changed
 
-- Upgraded AppVersion to 0.38.1
+-   Upgraded AppVersion to 0.38.1
 
 ## 1.0.10
 
 ### Changed
 
-- Upgraded AppVersion to 0.38.0
+-   Upgraded AppVersion to 0.38.0
 
 ## 1.0.9
 
 ### Changed
 
-- Upgraded AppVersion to 0.37.0
+-   Upgraded AppVersion to 0.37.0
 
 ## 1.0.8
 
 ### Changed
 
-- Upgraded AppVersion to 0.36.0
+-   Upgraded AppVersion to 0.36.0
 
 ## 1.0.7
 
 ### Changed
 
-- Upgraded AppVersion to 0.35.0
+-   Upgraded AppVersion to 0.35.0
 
 ## 1.0.6
 
 ### Changed
 
-- Upgraded AppVersion to 0.34.0
+-   Upgraded AppVersion to 0.34.0
 
 ## 1.0.5
 
 ### Changed
 
-- Upgraded AppVersion to 0.33.0
+-   Upgraded AppVersion to 0.33.0
 
 ## 1.0.4
 
 ### Changed
 
-- Upgraded AppVersion to 0.32.1
+-   Upgraded AppVersion to 0.32.1
 
 ## 1.0.3
 
 ### Changed
 
-- Upgraded AppVersion to 0.32.0
+-   Upgraded AppVersion to 0.32.0
 
 ## 1.0.2
 
 ### Changed
 
-- Upgraded AppVersion to 0.31.0
+-   Upgraded AppVersion to 0.31.0
 
 ## 1.0.1
 
 ### Changed
 
-- Upgraded AppVersion to 0.30.0
+-   Upgraded AppVersion to 0.30.0
 
 ## 1.0.0
 
@@ -72,4 +84,4 @@
 
 ### Changed
 
-- Set the appVersion field in the chart metadata; the chart will default to using it as a docker tag, if `image.tag` in the values is unset.
+-   Set the appVersion field in the chart metadata; the chart will default to using it as a docker tag, if `image.tag` in the values is unset.

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -3,16 +3,16 @@ name: substra-frontend
 description: Frontend for Substra
 icon: https://avatars.githubusercontent.com/u/84009910?s=400
 keywords:
-  - substra
+    - substra
 sources:
-  - https://github.com/Substra/substra-frontend
+    - https://github.com/Substra/substra-frontend
 
 type: application
 
 maintainers:
-  - name: Substra Team
-    email: support@substra.org
+    - name: Substra Team
+      email: support@substra.org
 
-version: 1.0.12
+version: 1.0.13
 appVersion: 0.38.1 # should be same as in package.json
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: '>= 1.19.0-0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "substra-frontend",
-    "version": "0.38.1",
+    "version": "0.39.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "substra-frontend",
-            "version": "0.38.1",
+            "version": "0.39.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@chakra-ui/react": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "license": "Apache-2.0",
     "private": "true",
-    "version": "0.38.1",
+    "version": "0.39.0",
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

## [0.39.0] - 2022-01-31

### Added

-   CP creators are available data (#124)
-   Contributing, contributors & code of conduct files (#157)

### Changed

-   Get tasks inputs & outputs assets from new endpoints (#144)
-   Change url displayed by vite in local (#163)

### Removed

-   test_only property from datasample type (#158)
