### PR TITLE
fix: perfcard tooltip position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Tooltip position on perf cards (#173)
+
 ## [0.39.2] - 2022-02-09
 
 ### Changed

--- a/src/components/PerfChartSummaryTooltip.tsx
+++ b/src/components/PerfChartSummaryTooltip.tsx
@@ -10,16 +10,10 @@ import { compareDataPoint } from '@/modules/series/SeriesUtils';
 import PerfChartTooltipItem from '@/components/PerfChartTooltipItem';
 
 type PerfChartTooltipProps = {
-    showTooltip: () => void;
-    hideTooltip: () => void;
-    canvasBoundingRect: DOMRect | undefined;
     points: DataPointT[];
 };
 
 const PerfChartSummaryTooltip = ({
-    showTooltip,
-    hideTooltip,
-    canvasBoundingRect,
     points,
 }: PerfChartTooltipProps): JSX.Element => {
     const { xAxisMode } = useContext(PerfBrowserContext);
@@ -31,23 +25,8 @@ const PerfChartSummaryTooltip = ({
 
     const remainingCount = Math.max(points.length - 5, 0);
 
-    // Position
-    // defaults to tooltip below the canvas
-    let top = 'calc(100% - 60px)';
-
-    // check if there is enough space below the canvas to display the full tooltip
-    // if there isn't, then place tooltip below the header, as we can't display it over
-    if (canvasBoundingRect) {
-        const tooltipHeight =
-            18 + // header
-            higherFivePoints.length * 36 + // items
-            (remainingCount > 0 ? 30 : 0) + // footer
-            24; // padding
-
-        if (tooltipHeight + canvasBoundingRect.bottom > window.innerHeight) {
-            top = `calc(-${canvasBoundingRect.top}px + 134px)`;
-        }
-    }
+    // Position tooltip at the bottom of the canvas
+    const top = `calc(100% - ${higherFivePoints.length * 36 + 24}px)`;
 
     return (
         <List
@@ -56,12 +35,14 @@ const PerfChartSummaryTooltip = ({
             top={top}
             left="0"
             right="0"
-            onMouseEnter={showTooltip}
-            onMouseLeave={hideTooltip}
+            // onMouseEnter={showTooltip}
+            // onMouseLeave={hideTooltip}
+            pointerEvents="none"
             padding="3"
             spacing="3"
             boxShadow="md"
             zIndex="dropdown"
+            bg="rgba(255,255,255,0.8)"
         >
             <ListItem
                 fontSize="xs"

--- a/src/hooks/usePerfChartTooltip.tsx
+++ b/src/hooks/usePerfChartTooltip.tsx
@@ -14,7 +14,6 @@ const usePerfChartTooltip = (
     const [points, setPoints] = useState<DataPointT[]>([]);
     const [position, setPosition] = useState({ x: 0, y: 0 });
     const [displayed, setDisplayed] = useState(false);
-    const [canvasBoundingRect, setCanvasBoundingRect] = useState<DOMRect>();
     const timeout = useRef<NodeJS.Timeout | null>(null);
 
     const showTooltip = () => {
@@ -35,12 +34,7 @@ const usePerfChartTooltip = (
     const tooltip =
         displayed &&
         (summary ? (
-            <PerfChartSummaryTooltip
-                hideTooltip={hideTooltip}
-                showTooltip={showTooltip}
-                canvasBoundingRect={canvasBoundingRect}
-                points={points}
-            />
+            <PerfChartSummaryTooltip points={points} />
         ) : (
             <PerfChartTooltip
                 hideTooltip={hideTooltip}
@@ -66,11 +60,7 @@ const usePerfChartTooltip = (
                             (dataPoint: { raw: DataPointT }) => dataPoint.raw
                         )
                     );
-                    if (summary) {
-                        setCanvasBoundingRect(
-                            context.chart.canvas.getBoundingClientRect()
-                        );
-                    } else {
+                    if (!summary) {
                         setPosition({
                             x: parseInt(tooltipModel.caretX),
                             y: parseInt(tooltipModel.caretY),


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1203124674173179/1203371810277187)

## Description

Fix the tooltip on performance cards in the performance tab in compute plan details page. 
Tried making just a bit transparent to not completely hide informations under. 

n.b: Waiting for decision to possibly remove the tooltip entirely instead.  
