### PR TITLE
fix: Fix task i/o display when opened from the cp tasks list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   BREAKING: rename Algo to Function (#170)
 
+### Fixed
+
+-   Inputs & outputs display when opening task drawer from cp tasks list (#175)
+
 ## [0.39.2] - 2022-02-09
 
 ### Changed

--- a/src/routes/tasks/components/TaskInputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskInputsDrawerSection.tsx
@@ -11,7 +11,6 @@ import {
 
 import AngleIcon from '@/assets/svg/angle-icon.svg';
 import useCanDownloadModel from '@/hooks/useCanDownloadModel';
-import useKeyFromPath from '@/hooks/useKeyFromPath';
 import { FileT, PermissionsT } from '@/modules/common/CommonTypes';
 import { getAllPages } from '@/modules/common/CommonUtils';
 import { isDatasetStubT } from '@/modules/datasets/DatasetsUtils';
@@ -405,16 +404,15 @@ const TaskInputsDrawerSection = ({
     taskLoading: boolean;
     task: TaskT | null;
 }): JSX.Element => {
-    const key = useKeyFromPath(PATHS.TASK);
     const [taskInputsAssets, setTaskInputsAssets] = useState<TaskIOT[]>([]);
 
     useEffect(() => {
-        if (key) {
-            getTaskInputAssets(key).then((result) =>
+        if (task) {
+            getTaskInputAssets(task.key).then((result) =>
                 setTaskInputsAssets(result)
             );
         }
-    }, [key]);
+    }, [task]);
 
     const getInputsAssets = (identifier: string): TaskIOT[] =>
         taskInputsAssets.filter(

--- a/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
@@ -13,13 +13,11 @@ import {
     Skeleton,
 } from '@chakra-ui/react';
 
-import useKeyFromPath from '@/hooks/useKeyFromPath';
 import { getAllPages } from '@/modules/common/CommonUtils';
 import { getAssetKindLabel } from '@/modules/functions/FunctionsUtils';
 import { ModelT } from '@/modules/tasks/ModelsTypes';
 import * as TasksApi from '@/modules/tasks/TasksApi';
 import { TaskT, TaskStatus, TaskIOT } from '@/modules/tasks/TasksTypes';
-import { PATHS } from '@/paths';
 
 import { DrawerSection } from '@/components/DrawerSection';
 
@@ -87,16 +85,15 @@ const TaskOutputsDrawerSection = ({
     taskLoading: boolean;
     task: TaskT | null;
 }) => {
-    const key = useKeyFromPath(PATHS.TASK);
     const [taskOutputsAssets, setTaskOutputsAssets] = useState<TaskIOT[]>([]);
 
     useEffect(() => {
-        if (key) {
-            getTaskOutputsAssets(key).then((result) =>
+        if (task) {
+            getTaskOutputsAssets(task.key).then((result) =>
                 setTaskOutputsAssets(result)
             );
         }
-    }, [key]);
+    }, [task]);
 
     return (
         <DrawerSection title="Outputs">


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1203124674173179/1203930713079452)

## Description

<!--- Describe your choices and changes in detail -->

When opening task drawer from the compute plan tasks list, the inputs & outputs weren't correctly fetched.
