### PR TITLE
fix: CP ordering by creation date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Inputs & outputs display when opening task drawer from cp tasks list (#175)
+-   CP ordering by creation date (#179)
 
 ### Removed
 

--- a/src/components/TableFilters/CreatorTableFilter.tsx
+++ b/src/components/TableFilters/CreatorTableFilter.tsx
@@ -5,12 +5,7 @@ import { Box, Checkbox, Text, VStack } from '@chakra-ui/react';
 import useAppSelector from '@/hooks/useAppSelector';
 import useDispatchWithAutoAbort from '@/hooks/useDispatchWithAutoAbort';
 import useSelection from '@/hooks/useSelection';
-import {
-    useCreator,
-    useMatch,
-    useOrdering,
-    usePage,
-} from '@/hooks/useSyncedState';
+import { useCreator, useMatch, usePage } from '@/hooks/useSyncedState';
 import { useTableFilterCallbackRefs } from '@/hooks/useTableFilters';
 import { listUsers } from '@/modules/users/UsersSlice';
 
@@ -31,11 +26,12 @@ const CreatorTableFilter = (): JSX.Element => {
     const dispatchWithAutoAbort = useDispatchWithAutoAbort();
     const [page] = usePage();
     const [match] = useMatch();
-    const [ordering] = useOrdering('username');
 
     useEffect(() => {
-        return dispatchWithAutoAbort(listUsers({ page, ordering, match }));
-    }, [page, ordering, match, dispatchWithAutoAbort]);
+        return dispatchWithAutoAbort(
+            listUsers({ page, ordering: 'username', match })
+        );
+    }, [page, match, dispatchWithAutoAbort]);
 
     const users = useAppSelector((state) => state.users.users);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1203124674173179/1204006128617828)

## Description

<!--- Describe your choices and changes in detail -->

## How to test

<!--- Provide some help tips to the technical reviewer -->

Ordering username list in creator filter used the hook useOrdering() which was interfering with the ordering of the CP table. Removed the hook's use as it is not necessary to call the user list in username order.

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

-   Think to update CHANGELOG.md before merge if needed !
