### PR TITLE
fix: improve perf loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Tooltip on perf cards (#178)
 -   `data_manager_key` and `data_samples` in `PerformanceT` (#182)
 -   `datasetKey` and `dataSampleKeys` in `SerieFeaturesT` (#182)
+-   Duplicated requests in performance pages (#180)
 
 ## [0.39.2] - 2022-02-09
 

--- a/src/modules/common/CommonUtils.ts
+++ b/src/modules/common/CommonUtils.ts
@@ -1,6 +1,8 @@
+import { AxiosPromise } from 'axios';
+
 import { capitalize as capitalizeString } from '@/libs/utils';
 
-import { AssetT } from './CommonTypes';
+import { AssetT, PaginatedApiResponseT } from './CommonTypes';
 
 const ASSET_LABEL: Record<AssetT, string> = {
     function: 'function',
@@ -22,4 +24,20 @@ export const getAssetLabel = (
         label = label + 's';
     }
     return label;
+};
+
+export const getAllPages = async <T>(
+    getPage: (page: number) => AxiosPromise<PaginatedApiResponseT<T>>,
+    pageSize: number
+): Promise<T[]> => {
+    let res: T[] = [];
+    let page = 1;
+    let lastPage = 1;
+    while (page <= lastPage) {
+        const response = await getPage(page);
+        res = [...res, ...response.data.results];
+        lastPage = Math.ceil(response.data.count / pageSize);
+        page += 1;
+    }
+    return res;
 };

--- a/src/modules/common/CommonUtils.ts
+++ b/src/modules/common/CommonUtils.ts
@@ -1,8 +1,6 @@
-import { AxiosPromise } from 'axios';
-
 import { capitalize as capitalizeString } from '@/libs/utils';
 
-import { AssetT, PaginatedApiResponseT } from './CommonTypes';
+import { AssetT } from './CommonTypes';
 
 const ASSET_LABEL: Record<AssetT, string> = {
     function: 'function',
@@ -24,20 +22,4 @@ export const getAssetLabel = (
         label = label + 's';
     }
     return label;
-};
-
-export const getAllPages = async <T>(
-    getPage: (page: number) => AxiosPromise<PaginatedApiResponseT<T>>,
-    pageSize: number
-): Promise<T[]> => {
-    let res: T[] = [];
-    let page = 1;
-    let lastPage = 1;
-    while (page <= lastPage) {
-        const response = await getPage(page);
-        res = [...res, ...response.data.results];
-        lastPage = Math.ceil(response.data.count / pageSize);
-        page += 1;
-    }
-    return res;
 };

--- a/src/modules/series/SeriesSlice.ts
+++ b/src/modules/series/SeriesSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { AxiosError } from 'axios';
 
-import { getAllPages } from '@/modules/common/CommonUtils';
 import * as ComputePlansApi from '@/modules/computePlans/ComputePlansApi';
 import {
     ComputePlanStatisticsT,
@@ -42,24 +41,7 @@ const getComputePlanSeries = async (
             { signal }
         );
         cpStats = response.data.compute_plan_statistics;
-    } catch (error) {
-        if (error instanceof AxiosError) {
-            return rejectWithValue(error.response?.data);
-        } else {
-            throw error;
-        }
-    }
-
-    try {
-        const pageSize = 100;
-        cpPerformances = await getAllPages(
-            (page) =>
-                ComputePlansApi.listComputePlanPerformances(
-                    { key: computePlanKey, pageSize, page },
-                    { signal }
-                ),
-            pageSize
-        );
+        cpPerformances = response.data.results;
     } catch (error) {
         if (error instanceof AxiosError) {
             return rejectWithValue(error.response?.data);


### PR DESCRIPTION
## Description

In the perforamnce page, we fetch all performances (as `pageSize: 0` returns all results and not 0 results) before refetching them using the pagination

## Companion PR

- https://github.com/Substra/substra-backend/pull/611
