### PR TITLE
feat: add SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Inter font for content body (#176)
 -   Task duration section in Task Drawer (#165)
+-   SSO on login page and API keys modal (#181)
 
 ### Changed
 

--- a/src/assets/chakraTheme.ts
+++ b/src/assets/chakraTheme.ts
@@ -204,6 +204,11 @@ export default extendTheme({
             },
         },
         Kbd: noDefaultBorderRadius,
+        Link: {
+            baseStyle: {
+                color: `primary.500`,
+            },
+        },
         Menu: {
             baseStyle: {
                 list: {

--- a/src/assets/chakraTheme.ts
+++ b/src/assets/chakraTheme.ts
@@ -185,6 +185,7 @@ export default extendTheme({
             baseStyle: {
                 ...noBorderRadius,
                 fontFamily: 'Gattica',
+                _hover: { textDecoration: 'none' },
             },
         },
         CloseButton: noDefaultBorderRadius,

--- a/src/assets/chakraTheme.ts
+++ b/src/assets/chakraTheme.ts
@@ -204,11 +204,6 @@ export default extendTheme({
             },
         },
         Kbd: noDefaultBorderRadius,
-        Link: {
-            baseStyle: {
-                color: `primary.500`,
-            },
-        },
         Menu: {
             baseStyle: {
                 list: {

--- a/src/components/ApiToken.tsx
+++ b/src/components/ApiToken.tsx
@@ -13,11 +13,12 @@ import {
 } from '@chakra-ui/react';
 
 import { useToast } from '@/hooks/useToast';
+import { requestToken } from '@/modules/bearerTokens/BearerTokenApi';
 import {
     BearerTokenT,
     NewBearerTokenT,
 } from '@/modules/bearerTokens/BearerTokenTypes';
-import { requestToken } from '@/modules/bearerTokens/BearerTokenUtils';
+import { parseNewToken } from '@/modules/bearerTokens/BearerTokenUtils';
 
 import CopyButton from './CopyButton';
 
@@ -27,55 +28,56 @@ const ApiToken = ({ token }: { token: BearerTokenT | NewBearerTokenT }) => {
     );
     const toast = useToast();
 
-    const getNewToken = () => {
-        requestToken()
-            .then((response) => {
-                setApiToken(response);
-                toast({
-                    title: 'Token regenerated',
-                    description: 'The old token is no longer valid.',
-                    status: 'success',
-                    isClosable: true,
-                });
-            })
-            .catch((error) => {
-                console.error(error);
-                toast({
-                    title: "Couldn't get a new token",
-                    description: 'Something went wrong',
-                    status: 'error',
-                    isClosable: true,
-                });
+    const getNewToken = async () => {
+        try {
+            const response = await requestToken();
+            setApiToken(parseNewToken(response.data));
+            toast({
+                title: 'Token regenerated',
+                descriptionComponent: 'The old token is no longer valid.',
+                status: 'success',
+                isClosable: true,
             });
+        } catch (error) {
+            console.error(error);
+            toast({
+                title: "Couldn't get a new token",
+                status: 'error',
+                isClosable: true,
+            });
+        }
     };
 
     const tokenIsExpired = apiToken.expires_at < new Date();
 
     return (
-        <Box border="1px" borderColor="gray.200" padding="10px">
+        <Box
+            borderWidth="1px"
+            borderStyle="solid"
+            borderColor="gray.100"
+            padding="2.5"
+        >
             <HStack>
                 <VStack align="left">
                     <Text fontSize="sm">
-                        {'Created ' + apiToken.created_at.toLocaleString()}
+                        {`Created ${apiToken.created_at.toLocaleString()}`}
                     </Text>
                     <Text
                         fontSize="sm"
                         color={tokenIsExpired ? 'red.500' : undefined}
                     >
-                        {'Expires ' + apiToken.expires_at.toLocaleString()}
+                        {`Expires ${apiToken.expires_at.toLocaleString()}`}
                     </Text>
-                    <HStack height="35px">
-                        {'token' in apiToken ? (
-                            <>
-                                <Code width="300px">{apiToken.token}</Code>
-                                <CopyButton value={apiToken.token} />
-                            </>
-                        ) : (
-                            <Text fontSize="sm" as="i">
-                                Generated tokens are only displayed once.
-                            </Text>
-                        )}
-                    </HStack>
+                    {'token' in apiToken ? (
+                        <HStack height="35px">
+                            <Code width="300px">{apiToken.token}</Code>
+                            <CopyButton value={apiToken.token} />
+                        </HStack>
+                    ) : (
+                        <Text height="35px" fontSize="sm" fontStyle="italic">
+                            Generated tokens are only displayed once.
+                        </Text>
+                    )}
                 </VStack>
                 <Spacer />
                 <Center width="120px">
@@ -87,7 +89,7 @@ const ApiToken = ({ token }: { token: BearerTokenT | NewBearerTokenT }) => {
                     >
                         <Button
                             onClick={getNewToken}
-                            disabled={'token' in apiToken}
+                            isDisabled={'token' in apiToken}
                         >
                             Regenerate
                         </Button>

--- a/src/components/ApiToken.tsx
+++ b/src/components/ApiToken.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+
+import {
+    Button,
+    Text,
+    Code,
+    VStack,
+    HStack,
+    Center,
+    Box,
+    useToast,
+    Spacer,
+} from '@chakra-ui/react';
+
+import { requestToken } from '@/modules/bearerTokens/BearerTokenApi';
+import {
+    BearerTokenT,
+    NewBearerTokenT,
+} from '@/modules/bearerTokens/BearerTokenTypes';
+
+import CopyButton from './CopyButton';
+
+const ApiToken = (props: { token: BearerTokenT | NewBearerTokenT }) => {
+    const [token, setToken] = useState<BearerTokenT | NewBearerTokenT>(
+        props.token
+    );
+    const toast = useToast();
+
+    function getNewToken() {
+        requestToken()
+            .then((response) => {
+                setToken(response);
+                toast({
+                    title: 'Token regenerated',
+                    description: 'The old token is no longer valid.',
+                    status: 'success',
+                    isClosable: true,
+                });
+            })
+            .catch((error) => {
+                console.error(error);
+            });
+    }
+
+    return (
+        <Box border="1px" borderColor="gray.200" padding="10px">
+            <HStack>
+                <VStack align="left">
+                    <Text fontSize="sm">
+                        {'Created ' + token.created.toLocaleString()}
+                    </Text>
+                    <Text fontSize="sm">
+                        {'Expires ' + token.expires_at.toLocaleString()}
+                    </Text>
+                    <HStack>
+                        {'token' in token ? (
+                            <>
+                                <Code fontSize="sm">{token.token}</Code>
+                                <CopyButton value={token.token} />
+                            </>
+                        ) : (
+                            <Text fontSize="sm" as="i">
+                                Generated tokens are only displayed once.
+                            </Text>
+                        )}
+                    </HStack>
+                </VStack>
+                <Spacer />
+                <Center>
+                    <Button onClick={getNewToken} disabled={'token' in token}>
+                        Regenerate
+                    </Button>
+                </Center>
+            </HStack>
+        </Box>
+    );
+};
+
+export default ApiToken;

--- a/src/components/ApiToken.tsx
+++ b/src/components/ApiToken.tsx
@@ -47,15 +47,22 @@ const ApiToken = (props: { token: BearerTokenT | NewBearerTokenT }) => {
             <HStack>
                 <VStack align="left">
                     <Text fontSize="sm">
-                        {'Created ' + token.created.toLocaleString()}
+                        {'Created ' + token.created_at.toLocaleString()}
                     </Text>
-                    <Text fontSize="sm">
+                    <Text
+                        fontSize="sm"
+                        color={
+                            token.expires_at < new Date()
+                                ? 'red.500'
+                                : undefined
+                        }
+                    >
                         {'Expires ' + token.expires_at.toLocaleString()}
                     </Text>
-                    <HStack>
+                    <HStack height="3em">
                         {'token' in token ? (
                             <>
-                                <Code fontSize="sm">{token.token}</Code>
+                                <Code width="30ch">{token.token}</Code>
                                 <CopyButton value={token.token} />
                             </>
                         ) : (

--- a/src/components/ApiToken.tsx
+++ b/src/components/ApiToken.tsx
@@ -13,11 +13,11 @@ import {
 } from '@chakra-ui/react';
 
 import { useToast } from '@/hooks/useToast';
-import { requestToken } from '@/modules/bearerTokens/BearerTokenApi';
 import {
     BearerTokenT,
     NewBearerTokenT,
 } from '@/modules/bearerTokens/BearerTokenTypes';
+import { requestToken } from '@/modules/bearerTokens/BearerTokenUtils';
 
 import CopyButton from './CopyButton';
 

--- a/src/components/ApiToken.tsx
+++ b/src/components/ApiToken.tsx
@@ -83,7 +83,7 @@ const ApiToken = ({ token }: { token: BearerTokenT | NewBearerTokenT }) => {
                         hasArrow
                         label="This will disable your existing token"
                         bg="red.500"
-                        isDisabled={tokenIsExpired}
+                        isDisabled={tokenIsExpired || 'token' in apiToken}
                     >
                         <Button
                             onClick={getNewToken}

--- a/src/components/layout/header/ApiKey.tsx
+++ b/src/components/layout/header/ApiKey.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react';
+
+import {
+    Button,
+    Text,
+    MenuItem,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    useDisclosure,
+    VStack,
+    Code,
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Td,
+    TableContainer,
+} from '@chakra-ui/react';
+
+import { retrieveToken } from '@/modules/bearerTokens/BearerTokenApi';
+import { fromRawToken } from '@/modules/bearerTokens/BearerTokenTypes';
+
+import CopyButton from '@/components/CopyButton';
+
+const ApiKey = () => {
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    const [token, setToken] = useState({
+        payload: 'Loading',
+        expiration: new Date(),
+    });
+    useEffect(() => {
+        retrieveToken()
+            .then((response) => {
+                setToken(fromRawToken(response.data));
+            })
+            .catch((error) => {
+                console.error(error);
+                setToken({ payload: 'Error', expiration: new Date() });
+            });
+    }, []);
+    return (
+        <>
+            <MenuItem onClick={onOpen}>API key</MenuItem>
+
+            <Modal isOpen={isOpen} onClose={onClose} size="xl">
+                <ModalOverlay />
+                <ModalContent>
+                    <ModalHeader>API key</ModalHeader>
+                    <ModalCloseButton />
+                    <ModalBody>
+                        <VStack alignItems="stretch" spacing="5">
+                            <Text>
+                                This API key can be used in the Python substra
+                                SDK.
+                            </Text>
+                            <TableContainer>
+                                <Table>
+                                    <Thead>
+                                        <Tr>
+                                            <Td>Key</Td>
+                                            <Td>Expiration</Td>
+                                        </Tr>
+                                    </Thead>
+                                    <Tbody>
+                                        <Tr>
+                                            <Td>
+                                                <Code>{token.payload}</Code>
+                                                <CopyButton
+                                                    value={token.payload}
+                                                />
+                                            </Td>
+                                            <Td>
+                                                {token.expiration.toString()}
+                                            </Td>
+                                        </Tr>
+                                    </Tbody>
+                                </Table>
+                            </TableContainer>
+                        </VStack>
+                    </ModalBody>
+
+                    <ModalFooter>
+                        <Button size="sm" onClick={onClose}>
+                            Close
+                        </Button>
+                    </ModalFooter>
+                </ModalContent>
+            </Modal>
+        </>
+    );
+};
+export default ApiKey;

--- a/src/components/layout/header/ApiTokens.tsx
+++ b/src/components/layout/header/ApiTokens.tsx
@@ -85,7 +85,7 @@ const ApiTokens = () => {
                                             size="sm"
                                             onClick={getFirstToken}
                                         >
-                                            Request a token
+                                            Generate a token
                                         </Button>
                                     </HStack>
                                 </Center>

--- a/src/components/layout/header/ApiTokens.tsx
+++ b/src/components/layout/header/ApiTokens.tsx
@@ -57,7 +57,14 @@ const ApiTokens = () => {
                     <ModalBody>
                         <VStack alignItems="stretch" spacing="5">
                             <Text>
-                                This API token can be used in the Substra Python Client: see <Link href="https://docs.substra.org/en/stable/documentation/references/sdk.html#client" isExternal>documentation</Link>.
+                                {'This API token can be used in the '}
+                                <Link
+                                    href="https://docs.substra.org/en/stable/documentation/references/sdk.html#client"
+                                    isExternal
+                                >
+                                    Substra Python Client
+                                </Link>
+                                .
                             </Text>
                             <TableContainer>
                                 <Table>

--- a/src/components/layout/header/ApiTokens.tsx
+++ b/src/components/layout/header/ApiTokens.tsx
@@ -18,10 +18,14 @@ import {
 } from '@chakra-ui/react';
 
 import { useToast } from '@/hooks/useToast';
-import { BearerTokenT } from '@/modules/bearerTokens/BearerTokenTypes';
 import {
     listActiveTokens,
     requestToken,
+} from '@/modules/bearerTokens/BearerTokenApi';
+import { BearerTokenT } from '@/modules/bearerTokens/BearerTokenTypes';
+import {
+    parseToken,
+    parseNewToken,
 } from '@/modules/bearerTokens/BearerTokenUtils';
 
 import ApiToken from '@/components/ApiToken';
@@ -31,30 +35,27 @@ const ApiTokens = () => {
     const [activeTokens, setActiveTokens] = useState<BearerTokenT[]>([]);
     const toast = useToast();
 
-    const getFirstToken = () => {
-        requestToken()
-            .then((response) => {
-                setActiveTokens([response]);
-            })
-            .catch((error) => {
-                console.error(error);
-                toast({
-                    title: "Couldn't get a new token",
-                    description: 'Something went wrong',
-                    status: 'error',
-                    isClosable: true,
-                });
+    const getFirstToken = async () => {
+        try {
+            const response = await requestToken();
+            setActiveTokens([parseNewToken(response.data)]);
+        } catch (error) {
+            console.error(error);
+            toast({
+                title: "Couldn't get a new token",
+                status: 'error',
+                isClosable: true,
             });
+        }
     };
 
-    const getActiveTokens = () => {
-        listActiveTokens()
-            .then((response) => {
-                setActiveTokens(response);
-            })
-            .catch((error) => {
-                console.error(error);
-            });
+    const getActiveTokens = async () => {
+        try {
+            const response = await listActiveTokens();
+            setActiveTokens(response.data.tokens.map(parseToken));
+        } catch (error) {
+            console.error(error);
+        }
     };
 
     useEffect(() => {

--- a/src/components/layout/header/ApiTokens.tsx
+++ b/src/components/layout/header/ApiTokens.tsx
@@ -18,11 +18,11 @@ import {
 } from '@chakra-ui/react';
 
 import { useToast } from '@/hooks/useToast';
+import { BearerTokenT } from '@/modules/bearerTokens/BearerTokenTypes';
 import {
     listActiveTokens,
     requestToken,
-} from '@/modules/bearerTokens/BearerTokenApi';
-import { BearerTokenT } from '@/modules/bearerTokens/BearerTokenTypes';
+} from '@/modules/bearerTokens/BearerTokenUtils';
 
 import ApiToken from '@/components/ApiToken';
 

--- a/src/components/layout/header/ApiTokens.tsx
+++ b/src/components/layout/header/ApiTokens.tsx
@@ -17,6 +17,7 @@ import {
     Center,
 } from '@chakra-ui/react';
 
+import { useToast } from '@/hooks/useToast';
 import {
     listActiveTokens,
     requestToken,
@@ -28,18 +29,25 @@ import ApiToken from '@/components/ApiToken';
 const ApiTokens = () => {
     const { isOpen, onOpen, onClose } = useDisclosure();
     const [activeTokens, setActiveTokens] = useState<BearerTokenT[]>([]);
+    const toast = useToast();
 
-    function getFirstToken() {
+    const getFirstToken = () => {
         requestToken()
             .then((response) => {
                 setActiveTokens([response]);
             })
             .catch((error) => {
                 console.error(error);
+                toast({
+                    title: "Couldn't get a new token",
+                    description: 'Something went wrong',
+                    status: 'error',
+                    isClosable: true,
+                });
             });
-    }
+    };
 
-    function getActiveTokens() {
+    const getActiveTokens = () => {
         listActiveTokens()
             .then((response) => {
                 setActiveTokens(response);
@@ -47,7 +55,7 @@ const ApiTokens = () => {
             .catch((error) => {
                 console.error(error);
             });
-    }
+    };
 
     useEffect(() => {
         getActiveTokens();
@@ -66,6 +74,7 @@ const ApiTokens = () => {
                             <Text>
                                 {'This API token can be used in the '}
                                 <Link
+                                    color="primary.500"
                                     href="https://docs.substra.org/en/stable/documentation/references/sdk.html#client"
                                     isExternal
                                 >

--- a/src/components/layout/header/ApiTokens.tsx
+++ b/src/components/layout/header/ApiTokens.tsx
@@ -8,50 +8,31 @@ import {
     ModalBody,
     ModalCloseButton,
     ModalContent,
-    ModalFooter,
     ModalHeader,
     ModalOverlay,
     useDisclosure,
     VStack,
     HStack,
-    Code,
-    Table,
-    Thead,
-    Tbody,
-    Tr,
-    Td,
-    TableContainer,
     Link,
+    Center,
 } from '@chakra-ui/react';
 
 import {
     listActiveTokens,
     requestToken,
 } from '@/modules/bearerTokens/BearerTokenApi';
-import {
-    BearerTokenT,
-    NewBearerTokenT,
-} from '@/modules/bearerTokens/BearerTokenTypes';
+import { BearerTokenT } from '@/modules/bearerTokens/BearerTokenTypes';
 
-import CopyButton from '@/components/CopyButton';
+import ApiToken from '@/components/ApiToken';
 
 const ApiTokens = () => {
     const { isOpen, onOpen, onClose } = useDisclosure();
-
     const [activeTokens, setActiveTokens] = useState<BearerTokenT[]>([]);
-    const [newTokenRequested, setNewTokenRequested] = useState(false);
-    const [newToken, setNewToken] = useState<NewBearerTokenT>({
-        token: '',
-        created: new Date(),
-        expires_at: new Date(),
-    });
 
-    function getNewToken() {
+    function getFirstToken() {
         requestToken()
             .then((response) => {
-                setNewToken(response.data);
-                setNewTokenRequested(true);
-                getActiveTokens();
+                setActiveTokens([response]);
             })
             .catch((error) => {
                 console.error(error);
@@ -61,7 +42,7 @@ const ApiTokens = () => {
     function getActiveTokens() {
         listActiveTokens()
             .then((response) => {
-                setActiveTokens(response.data.tokens);
+                setActiveTokens(response);
             })
             .catch((error) => {
                 console.error(error);
@@ -69,7 +50,6 @@ const ApiTokens = () => {
     }
 
     useEffect(() => {
-        setNewTokenRequested(false);
         getActiveTokens();
     }, [isOpen]);
     return (
@@ -93,59 +73,25 @@ const ApiTokens = () => {
                                 </Link>
                                 .
                             </Text>
-                            <TableContainer>
-                                <Table>
-                                    <Thead>
-                                        <Tr>
-                                            <Td>Created</Td>
-                                            <Td>Expires</Td>
-                                        </Tr>
-                                    </Thead>
-                                    <Tbody>
-                                        {activeTokens.length ? (
-                                            <Tr>
-                                                <Td>
-                                                    {activeTokens[0].created.toString()}
-                                                </Td>
-                                                <Td>
-                                                    {activeTokens[0].expires_at.toString()}
-                                                </Td>
-                                            </Tr>
-                                        ) : (
-                                            <Tr>No active tokens</Tr>
-                                        )}
-                                    </Tbody>
-                                </Table>
-                            </TableContainer>
-                            <Text>
-                                Warning: requesting a new token will invalidate
-                                the old one!
-                            </Text>
-                            <Button
-                                onClick={getNewToken}
-                                disabled={newTokenRequested}
-                            >
-                                Request a new token
-                            </Button>
-                            {newTokenRequested && (
-                                <>
-                                    <Text>
-                                        This token will only be shown once:
-                                    </Text>
-                                    <HStack>
-                                        <Code>{newToken.token}</Code>
-                                        <CopyButton value={newToken.token} />
+                            {activeTokens.length ? (
+                                <ApiToken token={activeTokens[0]} />
+                            ) : (
+                                <Center>
+                                    <HStack spacing="2">
+                                        <Text>
+                                            You don't have an active token.
+                                        </Text>
+                                        <Button
+                                            size="sm"
+                                            onClick={getFirstToken}
+                                        >
+                                            Request a token
+                                        </Button>
                                     </HStack>
-                                </>
+                                </Center>
                             )}
                         </VStack>
                     </ModalBody>
-
-                    <ModalFooter>
-                        <Button size="sm" onClick={onClose}>
-                            Close
-                        </Button>
-                    </ModalFooter>
                 </ModalContent>
             </Modal>
         </>

--- a/src/components/layout/header/ApiTokens.tsx
+++ b/src/components/layout/header/ApiTokens.tsx
@@ -20,6 +20,7 @@ import {
     Tr,
     Td,
     TableContainer,
+    Link,
 } from '@chakra-ui/react';
 
 import { retrieveToken } from '@/modules/bearerTokens/BearerTokenApi';
@@ -27,7 +28,7 @@ import { fromRawToken } from '@/modules/bearerTokens/BearerTokenTypes';
 
 import CopyButton from '@/components/CopyButton';
 
-const ApiKey = () => {
+const ApiTokens = () => {
     const { isOpen, onOpen, onClose } = useDisclosure();
 
     const [token, setToken] = useState({
@@ -46,24 +47,23 @@ const ApiKey = () => {
     }, []);
     return (
         <>
-            <MenuItem onClick={onOpen}>API key</MenuItem>
+            <MenuItem onClick={onOpen}>API token</MenuItem>
 
             <Modal isOpen={isOpen} onClose={onClose} size="xl">
                 <ModalOverlay />
                 <ModalContent>
-                    <ModalHeader>API key</ModalHeader>
+                    <ModalHeader>API token</ModalHeader>
                     <ModalCloseButton />
                     <ModalBody>
                         <VStack alignItems="stretch" spacing="5">
                             <Text>
-                                This API key can be used in the Python substra
-                                SDK.
+                                This API token can be used in the Substra Python Client: see <Link href="https://docs.substra.org/en/stable/documentation/references/sdk.html#client" isExternal>documentation</Link>.
                             </Text>
                             <TableContainer>
                                 <Table>
                                     <Thead>
                                         <Tr>
-                                            <Td>Key</Td>
+                                            <Td>Token</Td>
                                             <Td>Expiration</Td>
                                         </Tr>
                                     </Thead>
@@ -95,4 +95,4 @@ const ApiKey = () => {
         </>
     );
 };
-export default ApiKey;
+export default ApiTokens;

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -158,9 +158,7 @@ const Header = (): JSX.Element => {
                             size="sm"
                         />
                         <MenuList zIndex="popover">
-                            <MenuGroup title={username}>
-                                {/* hack to display username */}
-                            </MenuGroup>
+                            <MenuGroup title={username} />
                             <MenuDivider color="gray.200" />
                             {userRole === 'ADMIN' && (
                                 <MenuItem

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -26,7 +26,7 @@ import { PATHS } from '@/paths';
 
 import OmniSearch from '@/components/OmniSearch';
 import About from '@/components/layout/header/About';
-import ApiKey from '@/components/layout/header/ApiKey';
+import ApiTokens from '@/components/layout/header/ApiTokens';
 import HeaderNavigation from '@/components/layout/header/HeaderNavigation';
 import Help from '@/components/layout/header/Help';
 
@@ -176,7 +176,7 @@ const Header = (): JSX.Element => {
                             >
                                 Documentation
                             </MenuItem>
-                            <ApiKey />
+                            <ApiTokens />
                             <Help />
                             <About />
                             {MICROSOFT_CLARITY_ID && (

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -26,6 +26,7 @@ import { PATHS } from '@/paths';
 
 import OmniSearch from '@/components/OmniSearch';
 import About from '@/components/layout/header/About';
+import ApiKey from '@/components/layout/header/ApiKey';
 import HeaderNavigation from '@/components/layout/header/HeaderNavigation';
 import Help from '@/components/layout/header/Help';
 
@@ -175,6 +176,7 @@ const Header = (): JSX.Element => {
                             >
                                 Documentation
                             </MenuItem>
+                            <ApiKey />
                             <Help />
                             <About />
                             {MICROSOFT_CLARITY_ID && (

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -15,6 +15,7 @@ import {
     IconButton,
     Icon,
     Link as ChakraLink,
+    MenuGroup,
 } from '@chakra-ui/react';
 import { RiUser3Fill } from 'react-icons/ri';
 
@@ -135,7 +136,7 @@ const Header = (): JSX.Element => {
                         transitionDuration="200ms"
                         transitionTimingFunction="ease-in-out"
                     >
-                        Connected as <strong>{username}</strong> to
+                        Connected to
                     </Text>
                     <Text
                         color="gray.800"
@@ -157,6 +158,10 @@ const Header = (): JSX.Element => {
                             size="sm"
                         />
                         <MenuList zIndex="popover">
+                            <MenuGroup title={username}>
+                                {/* hack to display username */}
+                            </MenuGroup>
+                            <MenuDivider color="gray.200" />
                             {userRole === 'ADMIN' && (
                                 <MenuItem
                                     onClick={() => setLocation(PATHS.USERS)}

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -84,6 +84,7 @@ const Header = (): JSX.Element => {
     );
     const channel = useAppSelector((state) => state.me.info.channel);
     const userRole = useAppSelector((state) => state.me.info.user_role);
+    const username = useAppSelector((state) => state.me.info.user);
 
     const handleLogOut = () => {
         dispatch(logOut())
@@ -133,7 +134,7 @@ const Header = (): JSX.Element => {
                         transitionDuration="200ms"
                         transitionTimingFunction="ease-in-out"
                     >
-                        Connected to
+                        Connected as <strong>{username}</strong> to
                     </Text>
                     <Text
                         color="gray.800"

--- a/src/modules/bearerTokens/BearerTokenApi.ts
+++ b/src/modules/bearerTokens/BearerTokenApi.ts
@@ -1,38 +1,14 @@
 import API from '@/libs/request';
 
-import {
-    BearerTokenT,
-    NewBearerTokenT,
-    RawBearerTokenT,
-    RawNewBearerTokenT,
-} from './BearerTokenTypes';
-
-const API_TOKEN_URL = `/api-token`;
-const API_ACTIVE_TOKENS_URL = `/active-api-tokens`;
-
-const parseToken = (object: RawBearerTokenT): BearerTokenT => {
-    return {
-        created_at: new Date(object.created_at),
-        expires_at: new Date(object.expires_at),
-    };
-};
-
-const parseNewToken = (object: RawNewBearerTokenT): NewBearerTokenT => {
-    return {
-        token: object.token,
-        created_at: new Date(object.created_at),
-        expires_at: new Date(object.expires_at),
-    };
+const URLS = {
+    API_TOKEN: `/api-token`,
+    ACTIVE_API_TOKENS: `/active-api-tokens`,
 };
 
 export const requestToken = () => {
-    return API.authenticatedGet(API_TOKEN_URL).then((response) => {
-        return parseNewToken(response.data);
-    });
+    return API.authenticatedGet(URLS.API_TOKEN);
 };
 
 export const listActiveTokens = () => {
-    return API.authenticatedGet(API_ACTIVE_TOKENS_URL).then((response) => {
-        return (response.data.tokens as RawBearerTokenT[]).map(parseToken);
-    });
+    return API.authenticatedGet(URLS.ACTIVE_API_TOKENS);
 };

--- a/src/modules/bearerTokens/BearerTokenApi.ts
+++ b/src/modules/bearerTokens/BearerTokenApi.ts
@@ -1,14 +1,20 @@
+import { AxiosResponse } from 'axios';
+
 import API from '@/libs/request';
+
+import { RawBearerTokenT, RawNewBearerTokenT } from './BearerTokenTypes';
 
 const URLS = {
     API_TOKEN: `/api-token`,
     ACTIVE_API_TOKENS: `/active-api-tokens`,
 };
 
-export const requestToken = () => {
+export const requestToken = (): Promise<AxiosResponse<RawNewBearerTokenT>> => {
     return API.authenticatedGet(URLS.API_TOKEN);
 };
 
-export const listActiveTokens = () => {
+export const listActiveTokens = (): Promise<
+    AxiosResponse<{ tokens: RawBearerTokenT[] }>
+> => {
     return API.authenticatedGet(URLS.ACTIVE_API_TOKENS);
 };

--- a/src/modules/bearerTokens/BearerTokenApi.ts
+++ b/src/modules/bearerTokens/BearerTokenApi.ts
@@ -1,36 +1,38 @@
 import API from '@/libs/request';
 
-import { BearerTokenT, NewBearerTokenT, RawBearerTokenT, RawNewBearerTokenT } from './BearerTokenTypes';
+import {
+    BearerTokenT,
+    NewBearerTokenT,
+    RawBearerTokenT,
+    RawNewBearerTokenT,
+} from './BearerTokenTypes';
 
 const API_TOKEN_URL = `/api-token`;
 const API_ACTIVE_TOKENS_URL = `/active-api-tokens`;
 
 const parseToken = (object: RawBearerTokenT): BearerTokenT => {
     return {
-        "created": new Date(object.created),
-        "expires_at": new Date(object.expires_at),
-    }
-}
+        created_at: new Date(object.created_at),
+        expires_at: new Date(object.expires_at),
+    };
+};
 
 const parseNewToken = (object: RawNewBearerTokenT): NewBearerTokenT => {
     return {
-        "token": object.token,
-        "created": new Date(object.created),
-        "expires_at": new Date(object.expires_at),
-    }
-}
-
+        token: object.token,
+        created_at: new Date(object.created_at),
+        expires_at: new Date(object.expires_at),
+    };
+};
 
 export const requestToken = () => {
-    return API.authenticatedGet(API_TOKEN_URL)
-        .then((response) => {
-            return parseNewToken(response.data);
-        });
+    return API.authenticatedGet(API_TOKEN_URL).then((response) => {
+        return parseNewToken(response.data);
+    });
 };
 
 export const listActiveTokens = () => {
-    return API.authenticatedGet(API_ACTIVE_TOKENS_URL)
-        .then( response => {
-            return (<RawBearerTokenT[]>response.data.tokens).map(parseToken);
-        });
+    return API.authenticatedGet(API_ACTIVE_TOKENS_URL).then((response) => {
+        return (response.data.tokens as RawBearerTokenT[]).map(parseToken);
+    });
 };

--- a/src/modules/bearerTokens/BearerTokenApi.ts
+++ b/src/modules/bearerTokens/BearerTokenApi.ts
@@ -2,7 +2,7 @@ import { AxiosPromise } from 'axios';
 
 import API from '@/libs/request';
 
-import { RawBearerTokenT, BearerTokenT } from './BearerTokenTypes';
+import { RawBearerTokenT } from './BearerTokenTypes';
 
 const API_TOKEN_URL = `/api-token-tap`;
 

--- a/src/modules/bearerTokens/BearerTokenApi.ts
+++ b/src/modules/bearerTokens/BearerTokenApi.ts
@@ -2,10 +2,15 @@ import { AxiosPromise } from 'axios';
 
 import API from '@/libs/request';
 
-import { RawBearerTokenT } from './BearerTokenTypes';
+import { NewBearerTokenT, BunchOfBearerTokensT } from './BearerTokenTypes';
 
-const API_TOKEN_URL = `/api-token-tap`;
+const API_TOKEN_URL = `/api-token`;
+const API_ACTIVE_TOKENS_URL = `/active-api-tokens`;
 
-export const retrieveToken = (): AxiosPromise<RawBearerTokenT> => {
+export const requestToken = (): AxiosPromise<NewBearerTokenT> => {
     return API.authenticatedGet(API_TOKEN_URL);
+};
+
+export const listActiveTokens = (): AxiosPromise<BunchOfBearerTokensT> => {
+    return API.authenticatedGet(API_ACTIVE_TOKENS_URL);
 };

--- a/src/modules/bearerTokens/BearerTokenApi.ts
+++ b/src/modules/bearerTokens/BearerTokenApi.ts
@@ -1,0 +1,11 @@
+import { AxiosPromise } from 'axios';
+
+import API from '@/libs/request';
+
+import { RawBearerTokenT, BearerTokenT } from './BearerTokenTypes';
+
+const API_TOKEN_URL = `/api-token-tap`;
+
+export const retrieveToken = (): AxiosPromise<RawBearerTokenT> => {
+    return API.authenticatedGet(API_TOKEN_URL);
+};

--- a/src/modules/bearerTokens/BearerTokenApi.ts
+++ b/src/modules/bearerTokens/BearerTokenApi.ts
@@ -1,16 +1,36 @@
-import { AxiosPromise } from 'axios';
-
 import API from '@/libs/request';
 
-import { NewBearerTokenT, BunchOfBearerTokensT } from './BearerTokenTypes';
+import { BearerTokenT, NewBearerTokenT, RawBearerTokenT, RawNewBearerTokenT } from './BearerTokenTypes';
 
 const API_TOKEN_URL = `/api-token`;
 const API_ACTIVE_TOKENS_URL = `/active-api-tokens`;
 
-export const requestToken = (): AxiosPromise<NewBearerTokenT> => {
-    return API.authenticatedGet(API_TOKEN_URL);
+const parseToken = (object: RawBearerTokenT): BearerTokenT => {
+    return {
+        "created": new Date(object.created),
+        "expires_at": new Date(object.expires_at),
+    }
+}
+
+const parseNewToken = (object: RawNewBearerTokenT): NewBearerTokenT => {
+    return {
+        "token": object.token,
+        "created": new Date(object.created),
+        "expires_at": new Date(object.expires_at),
+    }
+}
+
+
+export const requestToken = () => {
+    return API.authenticatedGet(API_TOKEN_URL)
+        .then((response) => {
+            return parseNewToken(response.data);
+        });
 };
 
-export const listActiveTokens = (): AxiosPromise<BunchOfBearerTokensT> => {
-    return API.authenticatedGet(API_ACTIVE_TOKENS_URL);
+export const listActiveTokens = () => {
+    return API.authenticatedGet(API_ACTIVE_TOKENS_URL)
+        .then( response => {
+            return (<RawBearerTokenT[]>response.data.tokens).map(parseToken);
+        });
 };

--- a/src/modules/bearerTokens/BearerTokenTypes.ts
+++ b/src/modules/bearerTokens/BearerTokenTypes.ts
@@ -1,0 +1,17 @@
+export type BearerTokenT = {
+    payload: string;
+    expiration: Date;
+};
+
+export const fromRawToken = (token: RawBearerTokenT): BearerTokenT => {
+    return {
+        payload: token.token,
+        expiration: new Date(Date.now() + token.expires_at * 1000),
+    };
+};
+
+// as returned by the endpoint
+export type RawBearerTokenT = {
+    token: string;
+    expires_at: number; // seconds
+};

--- a/src/modules/bearerTokens/BearerTokenTypes.ts
+++ b/src/modules/bearerTokens/BearerTokenTypes.ts
@@ -1,4 +1,4 @@
-export type BearerTokenT = {
+type BearerTokenT = {
     payload: string;
     expiration: Date;
 };

--- a/src/modules/bearerTokens/BearerTokenTypes.ts
+++ b/src/modules/bearerTokens/BearerTokenTypes.ts
@@ -2,9 +2,11 @@ export type BearerTokenT = {
     created: Date;
     expires_at: Date;
 };
-
 export type NewBearerTokenT = BearerTokenT & { token: string };
 
-export type BunchOfBearerTokensT = {
-    tokens: BearerTokenT[];
+// API response
+export type RawBearerTokenT = {
+    created: string;
+    expires_at: string;
 };
+export type RawNewBearerTokenT = RawBearerTokenT & { token: string };

--- a/src/modules/bearerTokens/BearerTokenTypes.ts
+++ b/src/modules/bearerTokens/BearerTokenTypes.ts
@@ -1,17 +1,10 @@
-type BearerTokenT = {
-    payload: string;
-    expiration: Date;
+export type BearerTokenT = {
+    created: Date;
+    expires_at: Date;
 };
 
-export const fromRawToken = (token: RawBearerTokenT): BearerTokenT => {
-    return {
-        payload: token.token,
-        expiration: new Date(Date.now() + token.expires_at * 1000),
-    };
-};
+export type NewBearerTokenT = BearerTokenT & { token: string };
 
-// as returned by the endpoint
-export type RawBearerTokenT = {
-    token: string;
-    expires_at: number; // seconds
+export type BunchOfBearerTokensT = {
+    tokens: BearerTokenT[];
 };

--- a/src/modules/bearerTokens/BearerTokenTypes.ts
+++ b/src/modules/bearerTokens/BearerTokenTypes.ts
@@ -1,12 +1,12 @@
 export type BearerTokenT = {
-    created: Date;
+    created_at: Date;
     expires_at: Date;
 };
 export type NewBearerTokenT = BearerTokenT & { token: string };
 
 // API response
 export type RawBearerTokenT = {
-    created: string;
+    created_at: string;
     expires_at: string;
 };
 export type RawNewBearerTokenT = RawBearerTokenT & { token: string };

--- a/src/modules/bearerTokens/BearerTokenUtils.ts
+++ b/src/modules/bearerTokens/BearerTokenUtils.ts
@@ -1,0 +1,37 @@
+import {
+    listActiveTokens as listActiveTokensFromApi,
+    requestToken as requestTokensFromApi,
+} from './BearerTokenApi';
+import {
+    BearerTokenT,
+    NewBearerTokenT,
+    RawBearerTokenT,
+    RawNewBearerTokenT,
+} from './BearerTokenTypes';
+
+const parseToken = (object: RawBearerTokenT): BearerTokenT => {
+    return {
+        created_at: new Date(object.created_at),
+        expires_at: new Date(object.expires_at),
+    };
+};
+
+const parseNewToken = (object: RawNewBearerTokenT): NewBearerTokenT => {
+    return {
+        token: object.token,
+        created_at: new Date(object.created_at),
+        expires_at: new Date(object.expires_at),
+    };
+};
+
+export const requestToken = (): Promise<NewBearerTokenT> => {
+    return requestTokensFromApi().then((response) => {
+        return parseNewToken(response.data);
+    });
+};
+
+export const listActiveTokens = (): Promise<BearerTokenT[]> => {
+    return listActiveTokensFromApi().then((response) => {
+        return (response.data.tokens as RawBearerTokenT[]).map(parseToken);
+    });
+};

--- a/src/modules/bearerTokens/BearerTokenUtils.ts
+++ b/src/modules/bearerTokens/BearerTokenUtils.ts
@@ -1,37 +1,21 @@
 import {
-    listActiveTokens as listActiveTokensFromApi,
-    requestToken as requestTokensFromApi,
-} from './BearerTokenApi';
-import {
     BearerTokenT,
     NewBearerTokenT,
     RawBearerTokenT,
     RawNewBearerTokenT,
 } from './BearerTokenTypes';
 
-const parseToken = (object: RawBearerTokenT): BearerTokenT => {
+export const parseToken = (object: RawBearerTokenT): BearerTokenT => {
     return {
         created_at: new Date(object.created_at),
         expires_at: new Date(object.expires_at),
     };
 };
 
-const parseNewToken = (object: RawNewBearerTokenT): NewBearerTokenT => {
+export const parseNewToken = (object: RawNewBearerTokenT): NewBearerTokenT => {
     return {
         token: object.token,
         created_at: new Date(object.created_at),
         expires_at: new Date(object.expires_at),
     };
-};
-
-export const requestToken = (): Promise<NewBearerTokenT> => {
-    return requestTokensFromApi().then((response) => {
-        return parseNewToken(response.data);
-    });
-};
-
-export const listActiveTokens = (): Promise<BearerTokenT[]> => {
-    return listActiveTokensFromApi().then((response) => {
-        return (response.data.tokens as RawBearerTokenT[]).map(parseToken);
-    });
 };

--- a/src/modules/me/MeSlice.ts
+++ b/src/modules/me/MeSlice.ts
@@ -59,6 +59,7 @@ const initialState: MeStateT = {
         config: {},
         user: '',
         user_role: UserRolesT.user,
+        auth: {},
     },
     infoLoading: false,
     infoError: '',

--- a/src/modules/me/MeTypes.ts
+++ b/src/modules/me/MeTypes.ts
@@ -12,4 +12,12 @@ export type MeInfoT = {
     };
     user: string;
     user_role: UserRolesT;
+    auth: MeInfoAuthT;
 };
+
+type MeInfoAuthT = {
+    oidc?: {
+        name: string;
+        login_url: string;
+    }
+}

--- a/src/modules/me/MeTypes.ts
+++ b/src/modules/me/MeTypes.ts
@@ -19,5 +19,5 @@ type MeInfoAuthT = {
     oidc?: {
         name: string;
         login_url: string;
-    }
-}
+    };
+};

--- a/src/routes/login/components/LoginForm.tsx
+++ b/src/routes/login/components/LoginForm.tsx
@@ -32,16 +32,14 @@ const LoginForm = (): JSX.Element => {
     const [showPassword, setShowPassword] = useState(false);
     const dispatch = useAppDispatch();
     const [, setLocation] = useLocation();
-    const authInfo = useAppSelector(
-        (state) => state.me.info.auth
-    );
+    const authInfo = useAppSelector((state) => state.me.info.auth);
 
     const organizationId = useAppSelector(
         (state) => state.me.info.organization_id
     );
     const userLoading = useAppSelector((state) => state.me.loading);
     const userError = useAppSelector((state) => state.me.error);
-    
+
     const urlSearchParams = new URLSearchParams(window.location.search);
     const nextLocation = urlSearchParams.get('next') || PATHS.COMPUTE_PLANS;
 
@@ -77,17 +75,24 @@ const LoginForm = (): JSX.Element => {
                 <Text fontWeight="semibold" fontSize="3xl" marginBottom="4">
                     Login to {organizationId}
                 </Text>
-                
+
                 {authInfo?.oidc && (
                     <div>
-                        <a href={`${API_URL}${authInfo.oidc.login_url}?next=`+encodeURIComponent(window.location.origin+nextLocation)}>
+                        <a
+                            href={
+                                `${API_URL}${authInfo.oidc.login_url}?next=` +
+                                encodeURIComponent(
+                                    window.location.origin + nextLocation
+                                )
+                            }
+                        >
                             <Button width="100%" marginBottom="4">
                                 Sign in with {authInfo.oidc.name}
                             </Button>
                         </a>
                         <hr
                             style={{
-                                height: 5
+                                height: 5,
                             }}
                         />
                     </div>

--- a/src/routes/login/components/LoginForm.tsx
+++ b/src/routes/login/components/LoginForm.tsx
@@ -80,18 +80,18 @@ const LoginForm = (): JSX.Element => {
 
                 {authInfo?.oidc && (
                     <Box>
-                        <Link
-                            href={
-                                `${API_URL}${authInfo.oidc.login_url}?next=` +
-                                encodeURIComponent(
-                                    window.location.origin + nextLocation
-                                )
-                            }
+                        <Button
+                            width="100%"
+                            marginBottom="4"
+                            as={Link}
+                            href={`${API_URL}${
+                                authInfo.oidc.login_url
+                            }?next=${encodeURIComponent(
+                                window.location.origin + nextLocation
+                            )}`}
                         >
-                            <Button width="100%" marginBottom="4">
-                                Sign in with {authInfo.oidc.name}
-                            </Button>
-                        </Link>
+                            Sign in with {authInfo.oidc.name}
+                        </Button>
                         <Divider marginBottom="4" />
                     </Box>
                 )}

--- a/src/routes/login/components/LoginForm.tsx
+++ b/src/routes/login/components/LoginForm.tsx
@@ -32,22 +32,24 @@ const LoginForm = (): JSX.Element => {
     const [showPassword, setShowPassword] = useState(false);
     const dispatch = useAppDispatch();
     const [, setLocation] = useLocation();
+    const authInfo = useAppSelector(
+        (state) => state.me.info.auth
+    );
 
     const organizationId = useAppSelector(
         (state) => state.me.info.organization_id
     );
     const userLoading = useAppSelector((state) => state.me.loading);
     const userError = useAppSelector((state) => state.me.error);
+    
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const nextLocation = urlSearchParams.get('next') || PATHS.COMPUTE_PLANS;
 
     const submitLogin = async (username: string, password: string) => {
         const payload: LoginPayloadT = {
             username,
             password,
         };
-        const urlSearchParams = new URLSearchParams(window.location.search);
-
-        const nextLocation = urlSearchParams.get('next') || PATHS.COMPUTE_PLANS;
-
         dispatch(logIn(payload))
             .then(unwrapResult)
             .then(
@@ -75,6 +77,22 @@ const LoginForm = (): JSX.Element => {
                 <Text fontWeight="semibold" fontSize="3xl" marginBottom="4">
                     Login to {organizationId}
                 </Text>
+                
+                {authInfo?.oidc && (
+                    <div>
+                        <a href={`${API_URL}${authInfo.oidc.login_url}?next=`+encodeURIComponent(window.location.origin+nextLocation)}>
+                            <Button width="100%" marginBottom="4">
+                                Sign in with {authInfo.oidc.name}
+                            </Button>
+                        </a>
+                        <hr
+                            style={{
+                                height: 5
+                            }}
+                        />
+                    </div>
+                )}
+
                 {userError && (
                     <Alert
                         marginY="4"

--- a/src/routes/login/components/LoginForm.tsx
+++ b/src/routes/login/components/LoginForm.tsx
@@ -16,6 +16,8 @@ import {
     AlertIcon,
     AlertTitle,
     AlertDescription,
+    Link,
+    Divider,
 } from '@chakra-ui/react';
 import { RiErrorWarningLine, RiEyeLine, RiEyeOffLine } from 'react-icons/ri';
 
@@ -77,8 +79,8 @@ const LoginForm = (): JSX.Element => {
                 </Text>
 
                 {authInfo?.oidc && (
-                    <div>
-                        <a
+                    <Box>
+                        <Link
                             href={
                                 `${API_URL}${authInfo.oidc.login_url}?next=` +
                                 encodeURIComponent(
@@ -89,13 +91,9 @@ const LoginForm = (): JSX.Element => {
                             <Button width="100%" marginBottom="4">
                                 Sign in with {authInfo.oidc.name}
                             </Button>
-                        </a>
-                        <hr
-                            style={{
-                                height: 5,
-                            }}
-                        />
-                    </div>
+                        </Link>
+                        <Divider marginBottom="4" />
+                    </Box>
                 )}
 
                 {userError && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Add mechanism to handle a new authentication flow: single sign-on (SSO) through OpenID Connect (OIDC).

Changes:
 - on the login page, we query the `/info` endpoint to see whether SSO is available, and if so present a button. All the button does is redirect to the backend at `/oidc/authenticate?next={some frontend page}`. The backend does everything else
 - add the current username in the header menu, because with SSO the username is not obvious
 - add an "API tokens" modal (in the header menu) so SSO users can use the library (they don't have a password).
   
   In the future we will deprecate logging in on the command line, and that modal will be a nice interface for creating and managing API tokens. Probably.

Issues: _(to be fixed in a future PR, presumably)_
 - active tokens make too many requests and should go through Redux
 - API tokens modal is ugly



## How to test

Only the actual login requires special set-up.

Set up an SSO-capable backend: https://github.com/Substra/substra-backend/pull/609

Then just edit `vite.config.ts` to point to `http://substra-backend.org-1.com` (without the port number, because we're hosting on the cluster rather than in isolated mode). That should be it.

It's also possible to test the frontend in isolated mode but that requires more set-up on the backend so I'll let you figure it out.

## To do

- [x] update changelog
- [x] ~~investigate login/logout redirects (using the logout button and then logging in again works weird)~~ can't reproduce