### PR TITLE
chore: remove `ComputeTask` pr-GT links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 -   Tooltip on perf cards (#178)
+-   `data_manager_key` and `data_samples` in `PerformanceT` (#182)
+-   `datasetKey` and `dataSampleKeys` in `SerieFeaturesT` (#182)
 
 ## [0.39.2] - 2022-02-09
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -158,17 +158,3 @@ export const capitalize = (word: string) => {
     const lower = word.toLowerCase();
     return word.charAt(0).toUpperCase() + lower.slice(1);
 };
-
-export function areSetEqual(s1: Set<string>, s2: Set<string>): boolean {
-    if (s1.size !== s2.size) {
-        return false;
-    }
-
-    for (const v of s1) {
-        if (!s2.has(v)) {
-            return false;
-        }
-    }
-
-    return true;
-}

--- a/src/modules/perf/PerformancesTypes.ts
+++ b/src/modules/perf/PerformancesTypes.ts
@@ -1,7 +1,6 @@
 export type PerformanceT = {
     compute_task: {
         key: string;
-        data_manager_key: string;
         function_key: string;
         rank: number;
         round_idx: string | null;

--- a/src/modules/perf/PerformancesTypes.ts
+++ b/src/modules/perf/PerformancesTypes.ts
@@ -4,7 +4,6 @@ export type PerformanceT = {
         function_key: string;
         rank: number;
         round_idx: string | null;
-        data_samples: string[];
         worker: string;
     };
     metric: {

--- a/src/modules/series/SeriesTypes.ts
+++ b/src/modules/series/SeriesTypes.ts
@@ -2,7 +2,6 @@ import { ScatterDataPoint } from 'chart.js';
 
 export type SerieFeaturesT = {
     functionKey: string;
-    datasetKey: string;
     dataSampleKeys: string[];
     worker: string;
     metricKey: string;

--- a/src/modules/series/SeriesTypes.ts
+++ b/src/modules/series/SeriesTypes.ts
@@ -2,7 +2,6 @@ import { ScatterDataPoint } from 'chart.js';
 
 export type SerieFeaturesT = {
     functionKey: string;
-    dataSampleKeys: string[];
     worker: string;
     metricKey: string;
     metricName: string;

--- a/src/modules/series/SeriesUtils.ts
+++ b/src/modules/series/SeriesUtils.ts
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { areSetEqual } from '@/libs/utils';
 import { OrganizationT } from '@/modules/organizations/OrganizationsTypes';
 import { compareOrganizations } from '@/modules/organizations/OrganizationsUtils';
 import {
@@ -16,7 +15,6 @@ function buildSerieFeatures(
 ): SerieFeaturesT {
     return {
         functionKey: performance.compute_task.function_key,
-        dataSampleKeys: performance.compute_task.data_samples,
         worker: performance.compute_task.worker,
         metricKey: performance.metric.key,
         metricName: performance.metric.name,
@@ -30,8 +28,7 @@ function areSeriesEqual(sf1: SerieFeaturesT, sf2: SerieFeaturesT): boolean {
         sf1.functionKey === sf2.functionKey &&
         sf1.worker === sf2.worker &&
         sf1.metricKey === sf2.metricKey &&
-        sf1.metricOutputIdentifier === sf2.metricOutputIdentifier &&
-        areSetEqual(new Set(sf1.dataSampleKeys), new Set(sf2.dataSampleKeys))
+        sf1.metricOutputIdentifier === sf2.metricOutputIdentifier
     );
 }
 

--- a/src/modules/series/SeriesUtils.ts
+++ b/src/modules/series/SeriesUtils.ts
@@ -16,7 +16,6 @@ function buildSerieFeatures(
 ): SerieFeaturesT {
     return {
         functionKey: performance.compute_task.function_key,
-        datasetKey: performance.compute_task.data_manager_key,
         dataSampleKeys: performance.compute_task.data_samples,
         worker: performance.compute_task.worker,
         metricKey: performance.metric.key,
@@ -29,7 +28,6 @@ function buildSerieFeatures(
 function areSeriesEqual(sf1: SerieFeaturesT, sf2: SerieFeaturesT): boolean {
     return (
         sf1.functionKey === sf2.functionKey &&
-        sf1.datasetKey === sf2.datasetKey &&
         sf1.worker === sf2.worker &&
         sf1.metricKey === sf2.metricKey &&
         sf1.metricOutputIdentifier === sf2.metricOutputIdentifier &&


### PR DESCRIPTION
## Companion PR

- https://github.com/Substra/substra-backend/pull/614

## Description

In the backend, a ComputeTask was still linked with `data_samples` and `data_manager`, which were accessible in the `performance.compute_task` object. This has been removed as the planned way to access these objects is through `ComputeTaskInput`/`ComputeTaskOutput`.

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

