### PR TITLE
fix: Fix perf displaying as - when value is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Inputs & outputs display when opening task drawer from cp tasks list (#175)
 -   CP ordering by creation date (#179)
+-   Performance 0 displaying as `-`instead of `0.000`(#183)
 
 ### Removed
 

--- a/src/hooks/usePerfBrowser.ts
+++ b/src/hooks/usePerfBrowser.ts
@@ -306,7 +306,7 @@ const usePerfBrowser = (
                 const point = serie.points.find((p) => p[xAxisMode] === rank);
 
                 let perf = '-';
-                if (point?.perf) {
+                if (typeof point?.perf === 'number') {
                     perf = point.perf.toFixed(3);
                 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

### Linked to this [ASANA TASK](https://app.asana.com/0/1203124674173179/1203140248969175)

## Description

In compute plan details page & compare page, if perf was 0 it displayed as "-" instead of "0.000". 
