### PR TITLE
feat: Add functionName in workflow nodes & tasks table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Display the cause of CP not being cancellable in tooltip (#192)
+-   Display function name for each task in workflow & tasks table (#188)
 
 ### Changed
 

--- a/src/components/table/TasksTable.tsx
+++ b/src/components/table/TasksTable.tsx
@@ -174,18 +174,18 @@ const TasksTable = ({
                                     <OrderingTh
                                         options={[
                                             {
-                                                label: 'Worker',
+                                                label: 'Function',
                                                 asc: {
-                                                    label: 'Sort worker Z -> A',
-                                                    value: '-worker',
+                                                    label: 'Sort function Z -> A',
+                                                    value: '-function__name',
                                                 },
                                                 desc: {
-                                                    label: 'Sort worker A -> Z',
-                                                    value: 'worker',
+                                                    label: 'Sort function A -> Z',
+                                                    value: 'function__name',
                                                 },
                                             },
                                             {
-                                                label: 'Rank',
+                                                label: 'Rank-Worker',
                                                 asc: {
                                                     label: 'Sort rank lowest first',
                                                     value: 'rank',
@@ -351,9 +351,11 @@ const TasksTable = ({
                                                 />
                                             </Td>
                                             <Td>
-                                                <Text fontSize="sm">{`Task on ${task.worker}`}</Text>
+                                                <Text fontSize="sm">
+                                                    {task.function.name}
+                                                </Text>
                                                 <Text fontSize="xs">
-                                                    {`Rank ${task.rank}`}
+                                                    {`Rank ${task.rank} - ${task.worker}`}
                                                 </Text>
                                             </Td>
                                             <Td fontSize="xs">

--- a/src/routes/computePlanDetails/workflow/CPWorkflowLayout.spec.ts
+++ b/src/routes/computePlanDetails/workflow/CPWorkflowLayout.spec.ts
@@ -22,6 +22,7 @@ const twoTasksGraph: TaskGraphT = {
             key: 'a',
             rank: 0,
             worker: 'pharma1',
+            function_name: 'Training on MyAlgo',
             status: TaskStatus.done,
             inputs_specs: [],
             outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
@@ -29,6 +30,7 @@ const twoTasksGraph: TaskGraphT = {
         {
             key: 'b',
             rank: 1,
+            function_name: 'Training on MyAlgo',
             worker: 'pharma2',
             status: TaskStatus.failed,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
@@ -81,6 +83,7 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
         {
             key: 'predict_a',
             rank: 1,
+            function_name: 'Predict on MyAlgo',
             worker: 'pharma1',
             status: TaskStatus.done,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
@@ -89,6 +92,7 @@ const twoTasksPlusPredictAndTestTupleGraph: TaskGraphT = {
         {
             key: 'test_a',
             rank: 2,
+            function_name: 'Testing on MyAlgo',
             worker: 'pharma1',
             status: TaskStatus.done,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
@@ -157,6 +161,7 @@ const singleChainGraphWithBypassingEdge: TaskGraphT = {
             key: 'task_a',
             rank: 0,
             worker: 'pharma1',
+            function_name: 'Training on MyAlgo',
             status: TaskStatus.done,
             inputs_specs: [],
             outputs_specs: [
@@ -168,6 +173,7 @@ const singleChainGraphWithBypassingEdge: TaskGraphT = {
             key: 'task_b',
             rank: 1,
             worker: 'pharma1',
+            function_name: 'Training on MyAlgo',
             status: TaskStatus.failed,
             inputs_specs: [{ identifier: 'in_model', kind: 'ASSET_MODEL' }],
             outputs_specs: [{ identifier: 'out_model', kind: 'ASSET_MODEL' }],
@@ -176,6 +182,7 @@ const singleChainGraphWithBypassingEdge: TaskGraphT = {
             key: 'task_c',
             rank: 2,
             worker: 'pharma1',
+            function_name: 'Training on MyAlgo',
             status: TaskStatus.done,
             inputs_specs: [{ identifier: 'in_models', kind: 'ASSET_MODEL' }],
             outputs_specs: [],

--- a/src/routes/computePlanDetails/workflow/components/WorkflowTaskNode.tsx
+++ b/src/routes/computePlanDetails/workflow/components/WorkflowTaskNode.tsx
@@ -65,7 +65,9 @@ const TaskNode = ({ data }: TaskNodeProps) => {
                     backgroundColor={NODE_BORDER_COLOR[data.status]}
                     color="white"
                 >
-                    <Text fontWeight="bold">_</Text>
+                    <Text fontWeight="bold" noOfLines={1}>
+                        {data.function_name}
+                    </Text>
                     <Text
                         pos="absolute"
                         top="5px"

--- a/src/types/CPWorkflowTypes.ts
+++ b/src/types/CPWorkflowTypes.ts
@@ -13,6 +13,7 @@ type PlugT = {
 export type TaskT = {
     key: string;
     rank: number;
+    function_name: string;
     worker: string;
     status: TaskStatus;
     inputs_specs: PlugT[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Today it's very hard for a user to quickly get what is inside the task, both in the workflow tab or when looking at a task list.

This PR adds the function name for each task in the workflow & in the tasks table.

Companion PR : https://github.com/Substra/substra-backend/pull/635
