### PR TITLE
chore: Remove mention of Asana in gh PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,6 @@
 
 <!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->
 
-### Linked to this [ASANA TASK](link here)
-
 ## Description
 
 <!--- Describe your choices and changes in detail -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Removing entirely mentions of files not accessible to the open source community