### PR TITLE
fix: Inverted duration filter in tasks table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Inverted duration filter in tasks table (#190)
+
 ## [0.40.0] - 2023-03-29
 
 ### Added

--- a/src/components/TasksTable.tsx
+++ b/src/components/TasksTable.tsx
@@ -239,11 +239,11 @@ const TasksTable = ({
                                             {
                                                 label: 'Duration',
                                                 asc: {
-                                                    label: 'Sort duration shortest first',
+                                                    label: 'Sort duration longest first',
                                                     value: '-duration',
                                                 },
                                                 desc: {
-                                                    label: 'Sort duration longest first',
+                                                    label: 'Sort duration shortest first',
                                                     value: 'duration',
                                                 },
                                             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

 Fix bug in CP tasks table where using the ordering feature to order by shortest or longest task is giving the inverse of the expected result. 
