### PR TITLE
feat: cp uncancelable info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+-   Display the cause of CP not being cancellable in tooltip (#192)
+
 ### Changed
 
 -   Upgrade node version from 16.13.0 to 18.16.0 (#187)
 -   New icon for list ordering in tables (#191)
+-   CP cancel alert message (#192)
 
 ### Fixed
 

--- a/src/routes/computePlanDetails/components/CancelComputePlanDialog.tsx
+++ b/src/routes/computePlanDetails/components/CancelComputePlanDialog.tsx
@@ -8,6 +8,7 @@ import {
     AlertDialogBody,
     AlertDialogFooter,
     Button,
+    Text,
 } from '@chakra-ui/react';
 
 type CancelComputePlanDialogProps = {
@@ -29,7 +30,7 @@ const CancelComputePlanDialog = ({
             isOpen={isOpen}
             leastDestructiveRef={cancelRef}
             onClose={onClose}
-            size="sm"
+            size="md"
             closeOnEsc={!canceling}
             closeOnOverlayClick={!canceling}
         >
@@ -40,8 +41,14 @@ const CancelComputePlanDialog = ({
                     </AlertDialogHeader>
 
                     <AlertDialogBody>
-                        This will stop all ongoing tasks and cancel the
-                        execution of all remaining tasks.
+                        <Text>Tasks that have not started will not start.</Text>
+                        <Text>
+                            Tasks in DOING will continue until they are DONE.
+                        </Text>
+                        <Text>
+                            The compute plan status will be updated to
+                            CANCELLED.
+                        </Text>
                     </AlertDialogBody>
 
                     <AlertDialogFooter>

--- a/src/routes/computePlanDetails/components/CancelComputePlanMenuItem.tsx
+++ b/src/routes/computePlanDetails/components/CancelComputePlanMenuItem.tsx
@@ -2,15 +2,28 @@ import { MenuItemProps, MenuItem, Tooltip } from '@chakra-ui/react';
 
 type CancelComputePlanMenuItemProps = {
     onClick: MenuItemProps['onClick'];
-    isDisabled: boolean;
+    hasPermissions: boolean;
+    hasCancellableStatus: boolean;
 };
 const CancelComputePlanMenuItem = ({
     onClick,
-    isDisabled,
-}: CancelComputePlanMenuItemProps) =>
-    isDisabled ? (
+    hasPermissions,
+    hasCancellableStatus,
+}: CancelComputePlanMenuItemProps) => {
+    const isDisabled = !hasPermissions || !hasCancellableStatus;
+    let label;
+
+    if (!isDisabled) {
+        return <MenuItem onClick={onClick}>Cancel execution</MenuItem>;
+    } else if (hasPermissions) {
+        label = 'This compute plan cannot be canceled because of its state';
+    } else {
+        label =
+            "This compute plan cannot be canceled because you don't have permission to";
+    }
+    return (
         <Tooltip
-            label="This compute plan cannot be canceled: either because of its state or because you don't have permission to"
+            label={label}
             fontSize="xs"
             hasArrow
             placement="bottom-end"
@@ -20,8 +33,7 @@ const CancelComputePlanMenuItem = ({
                 Cancel execution
             </MenuItem>
         </Tooltip>
-    ) : (
-        <MenuItem onClick={onClick}>Cancel execution</MenuItem>
     );
+};
 
 export default CancelComputePlanMenuItem;

--- a/src/routes/computePlanDetails/components/CancelComputePlanMenuItem.tsx
+++ b/src/routes/computePlanDetails/components/CancelComputePlanMenuItem.tsx
@@ -10,10 +10,10 @@ const CancelComputePlanMenuItem = ({
     hasPermissions,
     hasCancellableStatus,
 }: CancelComputePlanMenuItemProps) => {
-    const isDisabled = !hasPermissions || !hasCancellableStatus;
+    const isEnabled = hasPermissions && hasCancellableStatus;
     let label;
 
-    if (!isDisabled) {
+    if (isEnabled) {
         return <MenuItem onClick={onClick}>Cancel execution</MenuItem>;
     } else if (hasPermissions) {
         label = 'This compute plan cannot be canceled because of its state';

--- a/src/routes/computePlanDetails/hooks/useCancelComputePlan.tsx
+++ b/src/routes/computePlanDetails/hooks/useCancelComputePlan.tsx
@@ -22,16 +22,20 @@ const useCancelComputePlan = (
     } = useAuthStore();
     const toast = useToast();
 
-    const isCancellable = useMemo(
+    const hasPermissions = useMemo(
+        (): boolean =>
+            computePlan !== null && computePlan.owner === currentOrganizationId,
+        [currentOrganizationId, computePlan]
+    );
+    const hasCancellableStatus = useMemo(
         (): boolean =>
             computePlan !== null &&
-            computePlan.owner === currentOrganizationId &&
             [
                 ComputePlanStatus.doing,
                 ComputePlanStatus.todo,
                 ComputePlanStatus.waiting,
             ].includes(computePlan.status),
-        [currentOrganizationId, computePlan]
+        [computePlan]
     );
 
     const cancelComputePlan = useCallback(async () => {
@@ -83,16 +87,17 @@ const useCancelComputePlan = (
     const cancelComputePlanMenuItem = useMemo(
         () => (
             <CancelComputePlanMenuItem
-                isDisabled={!isCancellable}
+                hasPermissions={hasPermissions}
+                hasCancellableStatus={hasCancellableStatus}
                 onClick={onOpen}
             />
         ),
-        [isCancellable, onOpen]
+        [hasPermissions, hasCancellableStatus, onOpen]
     );
 
     const cancelComputePlanDialog = useMemo(
         () =>
-            isCancellable ? (
+            hasPermissions && hasCancellableStatus ? (
                 <CancelComputePlanDialog
                     isOpen={isOpen}
                     onClose={onClose}
@@ -100,7 +105,14 @@ const useCancelComputePlan = (
                     canceling={canceling}
                 />
             ) : null,
-        [cancelComputePlan, canceling, isCancellable, isOpen, onClose]
+        [
+            cancelComputePlan,
+            canceling,
+            hasPermissions,
+            hasCancellableStatus,
+            isOpen,
+            onClose,
+        ]
     );
 
     return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

<!--- Describe your choices and changes in detail -->

Previously, on uncancellable CPs, a tooltip informed the user on the possibilities of why a CP could be uncancellable (namely not the permissions because of different organization or not the good status, aka already done, failed, etc). 
With this PR, tooltip will inform the user on why this particular CP is not cancellable, prioritizing permissions (i.e : if a cp is not cancellable for permissions AND status, tooltip will just inform about the permission reason).
Also a minor change on the alert describing what's gonna happen to the tasks when cancelling a CP. 
