### PR TITLE
feat: serialize through identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+-   Serialize the performance graph regarding the identifier only (#194)
+
 ### Added
 
 -   Display the cause of CP not being cancellable in tooltip (#192)

--- a/src/components/PerfDownloadButton.tsx
+++ b/src/components/PerfDownloadButton.tsx
@@ -25,10 +25,7 @@ const PerfDownloadButton = (): JSX.Element => {
 
     const { metadata } = useMetadataStore();
     const [selectedMetricKey] = useSyncedStringState('selectedMetricKey', '');
-    const [selectedMetricOutputIdentifier] = useSyncedStringState(
-        'selectedMetricOutputIdentifier',
-        ''
-    );
+    const [selectedIdentifier] = useSyncedStringState('selectedIdentifier', '');
 
     const [downloading, setDownloading] = useState(false);
     const download = async () => {
@@ -38,11 +35,11 @@ const PerfDownloadButton = (): JSX.Element => {
             metadata_columns: metadata.join(),
         };
 
-        if (selectedMetricKey && selectedMetricOutputIdentifier) {
+        if (selectedMetricKey && selectedIdentifier) {
             payload = {
                 ...payload,
                 metric_key: selectedMetricKey,
-                metric_output_identifier: selectedMetricOutputIdentifier,
+                metric_output_identifier: selectedIdentifier,
             };
         }
         const response = await exportPerformances(payload);

--- a/src/components/PerfDownloadButton.tsx
+++ b/src/components/PerfDownloadButton.tsx
@@ -16,16 +16,13 @@ import { exportPerformances } from '@/api/ComputePlansApi';
 import { downloadBlob } from '@/api/request';
 import useMetadataStore from '@/features/metadata/useMetadataStore';
 import { PerfBrowserContext } from '@/features/perfBrowser/usePerfBrowser';
-import { useSyncedStringState } from '@/hooks/useSyncedState';
 import { APIListArgsT } from '@/types/CommonTypes';
 
 const PerfDownloadButton = (): JSX.Element => {
-    const { computePlans, loading, selectedMetricName, perfChartRef } =
+    const { computePlans, loading, perfChartRef, selectedIdentifier } =
         useContext(PerfBrowserContext);
 
     const { metadata } = useMetadataStore();
-    const [selectedMetricKey] = useSyncedStringState('selectedMetricKey', '');
-    const [selectedIdentifier] = useSyncedStringState('selectedIdentifier', '');
 
     const [downloading, setDownloading] = useState(false);
     const download = async () => {
@@ -35,11 +32,10 @@ const PerfDownloadButton = (): JSX.Element => {
             metadata_columns: metadata.join(),
         };
 
-        if (selectedMetricKey && selectedIdentifier) {
+        if (selectedIdentifier) {
             payload = {
                 ...payload,
-                metric_key: selectedMetricKey,
-                metric_output_identifier: selectedIdentifier,
+                identifier: selectedIdentifier,
             };
         }
         const response = await exportPerformances(payload);
@@ -68,7 +64,7 @@ const PerfDownloadButton = (): JSX.Element => {
         }
     };
 
-    if (!selectedMetricName) {
+    if (!selectedIdentifier) {
         return (
             <Button
                 aria-label="Download chart"

--- a/src/features/perfBrowser/PerfBrowser.tsx
+++ b/src/features/perfBrowser/PerfBrowser.tsx
@@ -16,10 +16,8 @@ type PerfBrowserProps = {
 const PerfBrowser = ({ SidebarComponent }: PerfBrowserProps) => {
     const {
         loading,
-        selectedMetricName,
-        setSelectedMetricName,
-        setSelectedMetricKey,
-        setSelectedMetricOutputIdentifier,
+        selectedIdentifier,
+        setSelectedIdentifier,
         xAxisMode,
         seriesGroups,
         seriesGroupsWithRounds,
@@ -66,26 +64,18 @@ const PerfBrowser = ({ SidebarComponent }: PerfBrowserProps) => {
                     {loading && <PerfLoadingState />}
                     {!loading && (
                         <>
-                            {selectedMetricName && (
+                            {selectedIdentifier && (
                                 <PerfDetails series={selectedSeriesGroup} />
                             )}
-                            {!selectedMetricName && (
+                            {!selectedIdentifier && (
                                 <PerfList
                                     seriesGroups={
                                         xAxisMode === 'round'
                                             ? seriesGroupsWithRounds
                                             : seriesGroups
                                     }
-                                    onCardClick={(
-                                        metricName,
-                                        metricKey,
-                                        identifier
-                                    ) => {
-                                        setSelectedMetricName(metricName);
-                                        setSelectedMetricKey(metricKey);
-                                        setSelectedMetricOutputIdentifier(
-                                            identifier
-                                        );
+                                    onCardClick={(identifier) => {
+                                        setSelectedIdentifier(identifier);
                                     }}
                                 />
                             )}

--- a/src/features/perfBrowser/PerfBrowser.tsx
+++ b/src/features/perfBrowser/PerfBrowser.tsx
@@ -79,12 +79,12 @@ const PerfBrowser = ({ SidebarComponent }: PerfBrowserProps) => {
                                     onCardClick={(
                                         metricName,
                                         metricKey,
-                                        metricOutputIdentifier
+                                        identifier
                                     ) => {
                                         setSelectedMetricName(metricName);
                                         setSelectedMetricKey(metricKey);
                                         setSelectedMetricOutputIdentifier(
-                                            metricOutputIdentifier
+                                            identifier
                                         );
                                     }}
                                 />

--- a/src/features/perfBrowser/PerfDetails.tsx
+++ b/src/features/perfBrowser/PerfDetails.tsx
@@ -14,17 +14,11 @@ type PerfDetailsProps = {
 };
 
 const PerfDetails = ({ series }: PerfDetailsProps): JSX.Element => {
-    const {
-        perfChartRef,
-        setSelectedMetricName,
-        setSelectedMetricKey,
-        setSelectedMetricOutputIdentifier,
-    } = useContext(PerfBrowserContext);
+    const { perfChartRef, setSelectedIdentifier } =
+        useContext(PerfBrowserContext);
 
     const resetSelectedMetric = () => {
-        setSelectedMetricName('');
-        setSelectedMetricKey('');
-        setSelectedMetricOutputIdentifier('');
+        setSelectedIdentifier('');
     };
 
     useKeyPress('Escape', () => resetSelectedMetric());

--- a/src/features/perfBrowser/PerfList.tsx
+++ b/src/features/perfBrowser/PerfList.tsx
@@ -7,11 +7,7 @@ import { SerieT } from '@/types/SeriesTypes';
 
 type PerfListProps = {
     seriesGroups: SerieT[][];
-    onCardClick: (
-        metricName: string,
-        metricKey: string,
-        identifier: string
-    ) => void;
+    onCardClick: (identifier: string) => void;
 };
 const PerfList = ({ seriesGroups, onCardClick }: PerfListProps) => {
     return (
@@ -27,16 +23,10 @@ const PerfList = ({ seriesGroups, onCardClick }: PerfListProps) => {
             <PerfEmptyState seriesGroups={seriesGroups} />
             <Wrap spacing="3" justify="center">
                 {seriesGroups.map((series) => (
-                    <WrapItem key={`${series[0].metricKey}-${series[0].id}`}>
+                    <WrapItem key={`${series[0].identifier}-${series[0].id}`}>
                         <PerfCard
                             title={series[0].identifier}
-                            onClick={() =>
-                                onCardClick(
-                                    series[0].metricName,
-                                    series[0].metricKey,
-                                    series[0].identifier
-                                )
-                            }
+                            onClick={() => onCardClick(series[0].identifier)}
                         >
                             <PerfChart series={series} optionsEnabled={false} />
                         </PerfCard>

--- a/src/features/perfBrowser/PerfList.tsx
+++ b/src/features/perfBrowser/PerfList.tsx
@@ -10,7 +10,7 @@ type PerfListProps = {
     onCardClick: (
         metricName: string,
         metricKey: string,
-        metricOutputIdentifier: string
+        identifier: string
     ) => void;
 };
 const PerfList = ({ seriesGroups, onCardClick }: PerfListProps) => {
@@ -29,12 +29,12 @@ const PerfList = ({ seriesGroups, onCardClick }: PerfListProps) => {
                 {seriesGroups.map((series) => (
                     <WrapItem key={`${series[0].metricKey}-${series[0].id}`}>
                         <PerfCard
-                            title={series[0].metricName}
+                            title={series[0].identifier}
                             onClick={() =>
                                 onCardClick(
                                     series[0].metricName,
                                     series[0].metricKey,
-                                    series[0].metricOutputIdentifier
+                                    series[0].identifier
                                 )
                             }
                         >

--- a/src/features/perfBrowser/PerfSidebarCommon.tsx
+++ b/src/features/perfBrowser/PerfSidebarCommon.tsx
@@ -26,7 +26,7 @@ export const PerfSidebarContainer = ({
     title: string;
     children: React.ReactNode;
 }) => {
-    const { selectedMetricName, selectedRank, hoveredRank, xAxisMode } =
+    const { selectedIdentifier, selectedRank, hoveredRank, xAxisMode } =
         useContext(PerfBrowserContext);
     return (
         <Box padding="6">
@@ -39,7 +39,7 @@ export const PerfSidebarContainer = ({
                 paddingBottom={4}
             >
                 <Text>{title}</Text>
-                {selectedMetricName && (
+                {selectedIdentifier && (
                     <HStack color="gray.400" spacing="1">
                         <Text>
                             {selectedRank !== null &&

--- a/src/features/perfBrowser/PerfSidebarComputePlans.tsx
+++ b/src/features/perfBrowser/PerfSidebarComputePlans.tsx
@@ -329,7 +329,7 @@ const ComputePlanSection = ({
     addToFavorites,
     removeFromFavorites,
 }: ComputePlanSectionProps): JSX.Element => {
-    const { selectedMetricName } = useContext(PerfBrowserContext);
+    const { selectedIdentifier } = useContext(PerfBrowserContext);
     const { isOpen, onToggle } = useDisclosure({
         defaultIsOpen: true,
     });
@@ -345,7 +345,7 @@ const ComputePlanSection = ({
                 removeFromFavorites={removeFromFavorites}
             />
             <Collapse in={isOpen} animateOpacity>
-                {selectedMetricName ? (
+                {selectedIdentifier ? (
                     <SerieList computePlanKey={computePlanKey} />
                 ) : (
                     <OrganizationList computePlanKey={computePlanKey} />

--- a/src/features/perfBrowser/PerfSidebarLines.tsx
+++ b/src/features/perfBrowser/PerfSidebarLines.tsx
@@ -59,7 +59,7 @@ const SerieList = () => {
 };
 
 const PerfSidebarLines = (): JSX.Element => {
-    const { computePlans, loading, selectedMetricName } =
+    const { computePlans, loading, selectedIdentifier } =
         useContext(PerfBrowserContext);
 
     const computePlanKey = computePlans.length > 0 ? computePlans[0].key : '';
@@ -92,7 +92,7 @@ const PerfSidebarLines = (): JSX.Element => {
         );
     }
 
-    if (!selectedMetricName) {
+    if (!selectedIdentifier) {
         return <OrganizationList computePlanKey={computePlanKey} />;
     }
 

--- a/src/features/perfBrowser/usePerfBrowser.ts
+++ b/src/features/perfBrowser/usePerfBrowser.ts
@@ -64,7 +64,7 @@ type PerfBrowserContextT = {
     setSelectedMetricName: (name: string) => void;
     selectedMetricKey: string;
     setSelectedMetricKey: (name: string) => void;
-    selectedMetricOutputIdentifier: string;
+    selectedIdentifier: string;
     setSelectedMetricOutputIdentifier: (name: string) => void;
     selectedSeriesGroup: SerieT[];
     // Serie, compute plan and organization to highlight on charts
@@ -121,7 +121,7 @@ export const PerfBrowserContext = createContext<PerfBrowserContextT>({
     setSelectedMetricName: (name: string) => {},
     selectedMetricKey: '',
     setSelectedMetricKey: (name: string) => {},
-    selectedMetricOutputIdentifier: '',
+    selectedIdentifier: '',
     setSelectedMetricOutputIdentifier: (name: string) => {},
     selectedSeriesGroup: [],
     highlightedSerie: undefined,
@@ -167,8 +167,8 @@ const usePerfBrowser = (
         'selectedMetricKey',
         ''
     );
-    const [selectedMetricOutputIdentifier, setSelectedMetricOutputIdentifier] =
-        useSyncedStringState('selectedMetricOutputIdentifier', '');
+    const [selectedIdentifier, setSelectedMetricOutputIdentifier] =
+        useSyncedStringState('selectedIdentifier', '');
     const [highlightedSerie, setHighlightedSerie] =
         useState<HighlightedSerieT>();
     const [highlightedComputePlanKey, setHighlightedComputePlanKey] =
@@ -236,8 +236,8 @@ const usePerfBrowser = (
             (series) =>
                 series[0].metricKey.toLowerCase() ===
                     selectedMetricKey.toLowerCase() &&
-                series[0].metricOutputIdentifier.toLowerCase() ===
-                    selectedMetricOutputIdentifier.toLowerCase()
+                series[0].identifier.toLowerCase() ===
+                    selectedIdentifier.toLowerCase()
         );
 
         if (groupsMatchingMetric.length > 0) {
@@ -249,7 +249,7 @@ const usePerfBrowser = (
         seriesGroups,
         selectedMetricName,
         selectedMetricKey,
-        selectedMetricOutputIdentifier,
+        selectedIdentifier,
     ]);
 
     useEffect(() => {
@@ -446,7 +446,7 @@ const usePerfBrowser = (
             setSelectedMetricName,
             selectedMetricKey,
             setSelectedMetricKey,
-            selectedMetricOutputIdentifier,
+            selectedIdentifier,
             setSelectedMetricOutputIdentifier,
             selectedSeriesGroup,
             // event: highlighted serie, compute plan or organization

--- a/src/features/perfBrowser/usePerfBrowser.ts
+++ b/src/features/perfBrowser/usePerfBrowser.ts
@@ -59,13 +59,9 @@ type PerfBrowserContextT = {
     selectedComputePlanKeys: string[];
     setSelectedComputePlanKeys: (selectedComputePlanKeys: string[]) => void;
     onComputePlanKeySelectionChange: OnOptionChangeT;
-    // Currently selected metric with its series
-    selectedMetricName: string;
-    setSelectedMetricName: (name: string) => void;
-    selectedMetricKey: string;
-    setSelectedMetricKey: (name: string) => void;
+    // Currently selected identifier for metric with its series
     selectedIdentifier: string;
-    setSelectedMetricOutputIdentifier: (name: string) => void;
+    setSelectedIdentifier: (name: string) => void;
     selectedSeriesGroup: SerieT[];
     // Serie, compute plan and organization to highlight on charts
     highlightedSerie: HighlightedSerieT | undefined;
@@ -117,12 +113,8 @@ export const PerfBrowserContext = createContext<PerfBrowserContextT>({
     onComputePlanKeySelectionChange:
         (computePlanKey: string) =>
         (event: React.ChangeEvent<HTMLInputElement>) => {},
-    selectedMetricName: '',
-    setSelectedMetricName: (name: string) => {},
-    selectedMetricKey: '',
-    setSelectedMetricKey: (name: string) => {},
     selectedIdentifier: '',
-    setSelectedMetricOutputIdentifier: (name: string) => {},
+    setSelectedIdentifier: (name: string) => {},
     selectedSeriesGroup: [],
     highlightedSerie: undefined,
     setHighlightedSerie: (highlightedSerie) => {},
@@ -159,16 +151,10 @@ const usePerfBrowser = (
         useSyncedStringArrayState('selectedComputePlanKeys', []);
     const [hoveredRank, setHoveredRank] = useState<number | null>(null);
     const [selectedRank, setSelectedRank] = useState<number | null>(null);
-    const [selectedMetricName, setSelectedMetricName] = useSyncedStringState(
-        'selectedMetricName',
+    const [selectedIdentifier, setSelectedIdentifier] = useSyncedStringState(
+        'selectedIdentifier',
         ''
     );
-    const [selectedMetricKey, setSelectedMetricKey] = useSyncedStringState(
-        'selectedMetricKey',
-        ''
-    );
-    const [selectedIdentifier, setSelectedMetricOutputIdentifier] =
-        useSyncedStringState('selectedIdentifier', '');
     const [highlightedSerie, setHighlightedSerie] =
         useState<HighlightedSerieT>();
     const [highlightedComputePlanKey, setHighlightedComputePlanKey] =
@@ -228,16 +214,14 @@ const usePerfBrowser = (
     }, [series, selectedComputePlanKeys, isOrganizationIdSelected]);
 
     const selectedSeriesGroup = useMemo(() => {
-        if (!selectedMetricName) {
+        if (!selectedIdentifier) {
             return [];
         }
 
         const groupsMatchingMetric = seriesGroups.filter(
             (series) =>
-                series[0].metricKey.toLowerCase() ===
-                    selectedMetricKey.toLowerCase() &&
                 series[0].identifier.toLowerCase() ===
-                    selectedIdentifier.toLowerCase()
+                selectedIdentifier.toLowerCase()
         );
 
         if (groupsMatchingMetric.length > 0) {
@@ -245,12 +229,7 @@ const usePerfBrowser = (
         } else {
             return [];
         }
-    }, [
-        seriesGroups,
-        selectedMetricName,
-        selectedMetricKey,
-        selectedIdentifier,
-    ]);
+    }, [seriesGroups, selectedIdentifier]);
 
     useEffect(() => {
         setSelectedComputePlanKeys(
@@ -441,13 +420,9 @@ const usePerfBrowser = (
             selectedComputePlanKeys,
             onComputePlanKeySelectionChange,
             setSelectedComputePlanKeys,
-            // selected metric
-            selectedMetricName,
-            setSelectedMetricName,
-            selectedMetricKey,
-            setSelectedMetricKey,
+            // selected identifier for metric
             selectedIdentifier,
-            setSelectedMetricOutputIdentifier,
+            setSelectedIdentifier,
             selectedSeriesGroup,
             // event: highlighted serie, compute plan or organization
             highlightedSerie,

--- a/src/features/series/SeriesUtils.ts
+++ b/src/features/series/SeriesUtils.ts
@@ -22,7 +22,7 @@ function buildSerieFeatures(
         worker: performance.compute_task.worker,
         metricKey: performance.metric.key,
         metricName: performance.metric.name,
-        metricOutputIdentifier: performance.identifier,
+        identifier: performance.identifier,
         computePlanKey,
     };
 }
@@ -32,7 +32,7 @@ function areSeriesEqual(sf1: SerieFeaturesT, sf2: SerieFeaturesT): boolean {
         sf1.functionKey === sf2.functionKey &&
         sf1.worker === sf2.worker &&
         sf1.metricKey === sf2.metricKey &&
-        sf1.metricOutputIdentifier === sf2.metricOutputIdentifier
+        sf1.identifier === sf2.identifier
     );
 }
 
@@ -117,17 +117,14 @@ export function buildSeriesGroups(series: SerieT[]): SerieT[][] {
     const seriesGroupings = new Set(
         series.map((serie) =>
             JSON.stringify({
-                metricOutputIdentifier:
-                    serie.metricOutputIdentifier.toLowerCase(),
+                identifier: serie.identifier.toLowerCase(),
             })
         )
     );
     for (const seriesGrouping of seriesGroupings) {
-        const { metricOutputIdentifier } = JSON.parse(seriesGrouping);
+        const { identifier } = JSON.parse(seriesGrouping);
         const metricGroup = series.filter(
-            (serie) =>
-                serie.metricOutputIdentifier.toLowerCase() ===
-                metricOutputIdentifier
+            (serie) => serie.identifier.toLowerCase() === identifier
         );
 
         groups.push(metricGroup);

--- a/src/features/series/SeriesUtils.ts
+++ b/src/features/series/SeriesUtils.ts
@@ -20,8 +20,6 @@ function buildSerieFeatures(
     return {
         functionKey: performance.compute_task.function_key,
         worker: performance.compute_task.worker,
-        metricKey: performance.metric.key,
-        metricName: performance.metric.name,
         identifier: performance.identifier,
         computePlanKey,
     };
@@ -31,7 +29,6 @@ function areSeriesEqual(sf1: SerieFeaturesT, sf2: SerieFeaturesT): boolean {
     return (
         sf1.functionKey === sf2.functionKey &&
         sf1.worker === sf2.worker &&
-        sf1.metricKey === sf2.metricKey &&
         sf1.identifier === sf2.identifier
     );
 }

--- a/src/features/series/SeriesUtils.ts
+++ b/src/features/series/SeriesUtils.ts
@@ -22,7 +22,7 @@ function buildSerieFeatures(
         worker: performance.compute_task.worker,
         metricKey: performance.metric.key,
         metricName: performance.metric.name,
-        metricOutputIdentifier: performance.metric.output_identifier,
+        metricOutputIdentifier: performance.identifier,
         computePlanKey,
     };
 }
@@ -117,20 +117,17 @@ export function buildSeriesGroups(series: SerieT[]): SerieT[][] {
     const seriesGroupings = new Set(
         series.map((serie) =>
             JSON.stringify({
-                metricKey: serie.metricKey,
                 metricOutputIdentifier:
                     serie.metricOutputIdentifier.toLowerCase(),
             })
         )
     );
     for (const seriesGrouping of seriesGroupings) {
-        const { metricKey, metricOutputIdentifier } =
-            JSON.parse(seriesGrouping);
+        const { metricOutputIdentifier } = JSON.parse(seriesGrouping);
         const metricGroup = series.filter(
             (serie) =>
-                serie.metricKey === metricKey &&
                 serie.metricOutputIdentifier.toLowerCase() ===
-                    metricOutputIdentifier
+                metricOutputIdentifier
         );
 
         groups.push(metricGroup);

--- a/src/routes/compare/components/CompareBreadcrumbs.tsx
+++ b/src/routes/compare/components/CompareBreadcrumbs.tsx
@@ -9,7 +9,7 @@ import { PATHS } from '@/paths';
 import Breadcrumbs from '@/components/Breadcrumbs';
 
 const CompareBreadcrumbs = (): JSX.Element => {
-    const { selectedMetricName, setSelectedMetricName } =
+    const { selectedIdentifier, setSelectedIdentifier } =
         useContext(PerfBrowserContext);
 
     return (
@@ -18,15 +18,15 @@ const CompareBreadcrumbs = (): JSX.Element => {
             rootLabel="Compute plans"
             rootIcon={RiStackshareLine}
         >
-            <BreadcrumbItem isCurrentPage={!selectedMetricName}>
+            <BreadcrumbItem isCurrentPage={!selectedIdentifier}>
                 <HStack spacing="2.5">
-                    {selectedMetricName ? (
+                    {selectedIdentifier ? (
                         <Link
                             color="gray.500"
                             fontSize="sm"
                             fontWeight="medium"
                             lineHeight="5"
-                            onClick={() => setSelectedMetricName('')}
+                            onClick={() => setSelectedIdentifier('')}
                         >
                             Comparison
                         </Link>
@@ -42,7 +42,7 @@ const CompareBreadcrumbs = (): JSX.Element => {
                     )}
                 </HStack>
             </BreadcrumbItem>
-            {selectedMetricName && (
+            {selectedIdentifier && (
                 <BreadcrumbItem isCurrentPage>
                     <Text
                         color="black"
@@ -50,7 +50,7 @@ const CompareBreadcrumbs = (): JSX.Element => {
                         fontWeight="medium"
                         lineHeight="5"
                     >
-                        {selectedMetricName}
+                        {selectedIdentifier}
                     </Text>
                 </BreadcrumbItem>
             )}

--- a/src/routes/computePlanDetails/chart/components/ChartBreadCrumbs.tsx
+++ b/src/routes/computePlanDetails/chart/components/ChartBreadCrumbs.tsx
@@ -12,7 +12,7 @@ import Status from '@/components/Status';
 import useComputePlanStore from '../../useComputePlanStore';
 
 const ComputePlanChartBreadcrumbs = (): JSX.Element => {
-    const { selectedMetricName, setSelectedMetricName } =
+    const { selectedIdentifier, setSelectedIdentifier } =
         useContext(PerfBrowserContext);
 
     const { computePlan, fetchingComputePlan } = useComputePlanStore();
@@ -24,16 +24,16 @@ const ComputePlanChartBreadcrumbs = (): JSX.Element => {
             rootIcon={RiStackshareLine}
         >
             <BreadcrumbItem
-                isCurrentPage={fetchingComputePlan || !selectedMetricName}
+                isCurrentPage={fetchingComputePlan || !selectedIdentifier}
             >
                 <HStack spacing="2.5">
-                    {selectedMetricName ? (
+                    {selectedIdentifier ? (
                         <Link
                             color="gray.500"
                             fontSize="sm"
                             fontWeight="medium"
                             lineHeight="5"
-                            onClick={() => setSelectedMetricName('')}
+                            onClick={() => setSelectedIdentifier('')}
                         >
                             {fetchingComputePlan && 'Loading'}
                             {!fetchingComputePlan &&
@@ -62,7 +62,7 @@ const ComputePlanChartBreadcrumbs = (): JSX.Element => {
                     )}
                 </HStack>
             </BreadcrumbItem>
-            {!fetchingComputePlan && selectedMetricName && (
+            {!fetchingComputePlan && selectedIdentifier && (
                 <BreadcrumbItem isCurrentPage>
                     <Text
                         color="black"
@@ -70,7 +70,7 @@ const ComputePlanChartBreadcrumbs = (): JSX.Element => {
                         fontWeight="medium"
                         lineHeight="5"
                     >
-                        {selectedMetricName}
+                        {selectedIdentifier}
                     </Text>
                 </BreadcrumbItem>
             )}

--- a/src/types/PerformancesTypes.ts
+++ b/src/types/PerformancesTypes.ts
@@ -9,8 +9,8 @@ export type PerformanceT = {
     metric: {
         key: string;
         name: string;
-        output_identifier: string;
     };
+    identifier: string;
     perf: number | null;
 };
 

--- a/src/types/SeriesTypes.ts
+++ b/src/types/SeriesTypes.ts
@@ -3,8 +3,6 @@ import { ScatterDataPoint } from 'chart.js';
 export type SerieFeaturesT = {
     functionKey: string;
     worker: string;
-    metricKey: string;
-    metricName: string;
     identifier: string;
     computePlanKey: string;
 };

--- a/src/types/SeriesTypes.ts
+++ b/src/types/SeriesTypes.ts
@@ -5,7 +5,7 @@ export type SerieFeaturesT = {
     worker: string;
     metricKey: string;
     metricName: string;
-    metricOutputIdentifier: string;
+    identifier: string;
     computePlanKey: string;
 };
 


### PR DESCRIPTION
# Description

Performance asset were unique regarding their compute task key, and the function key they were computed from. Or, we want to have the possibility to have a function that outputs several performance and store them in the same task.

This implies two main things:
   - Performance are now unique regarding the compute task key, the function key AND the output identifier
   - The frontend must serialize regarding the identifier, and not the function key

The PR batch modify both the orchestrator and backend db in order to include the identifier as an additional unique condition.
In the backend, we use the ComputeTaskOutput as primary key directly.

## Companion PR

- https://github.com/Substra/substra-backend/pull/634
- https://github.com/Substra/substra-tests/pull/251 (main)
- https://github.com/Substra/orchestrator/pull/197
- https://github.com/Substra/substra-frontend/pull/194
- https://github.com/Substra/substra/pull/357

## E2E tests
- https://github.com/owkin/substra-ci/actions/runs/4872054802

- 