### PR TITLE
fix: Change the way tasks are ordered in each cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Inverted duration filter in tasks table (#190)
 -   Big refactor to use zustand instead of redux to handle store (#159)
 -   Change files architecture (#159)
+-   Better performances for workflow (#196)
 
 ## [0.40.0] - 2023-03-29
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

<!--- Describe your choices and changes in detail -->

Tasks used to be ordered by creating a unique name created by joining the name of all the parents recursively. This recursivity wasn't scoped correctly to each cell, creating a recursion far too heavy that could make the browser crash when getting in the 500ish tasks.
This PR changes the way this part of the code is handled by removing the creation of a unique name per task entirely and placing tasks in cell based on their rank & closest parent in each cell.

### How to test

I tried to test this on various CPs including edge cases such as test tasks being done on another org than the train ones.
