### PR TITLE
fix: Cancel list calls when reloading or changing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Moved the API tokens management to a new page supporting multiple token per user (#198)
 
+### Fixed
+
+-   Fixed list calls cancelling when reloading or changing page (#200)
+
 ## [0.41.0] - 2023-05-11
 
 ### Added
@@ -20,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+-   Big refactor to use zustand instead of redux to handle store (#159)
 -   Upgrade node version from 16.13.0 to 18.16.0 (#187)
 -   New icon for list ordering in tables (#191)
 -   CP cancel alert message (#192)
@@ -28,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Inverted duration filter in tasks table (#190)
--   Big refactor to use zustand instead of redux to handle store (#159)
 -   Change files architecture (#159)
 -   Better performances for workflow (#196)
 

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -7,7 +7,7 @@ import axios, {
 } from 'axios';
 import Cookies from 'universal-cookie';
 
-import { PaginatedApiResponseT } from '@/types/CommonTypes';
+import { AbortFunctionT, PaginatedApiResponseT } from '@/types/CommonTypes';
 
 const CONFIG = {
     baseURL: API_URL,
@@ -182,3 +182,17 @@ export const handleUnknownError = (error: unknown): string => {
     }
     return 'Unknown error';
 };
+
+// Used to create an abort controller for a given function
+// Returns a function launching abort to cancel the call of the func given as parameters when no longer needed
+// namely when making the same call twice (= reloading) or when unmounting useEffect (= changing page in app)
+// Cancelling unfinished calls that are no longer needed is for performance gains
+export const withAbortSignal =
+    <ParamsT extends unknown[]>(
+        func: (signal: AbortSignal, ...params: ParamsT) => void
+    ) =>
+    (...params: ParamsT): AbortFunctionT => {
+        const controller = new AbortController();
+        func(controller.signal, ...params);
+        return () => controller.abort();
+    };

--- a/src/components/table/TasksTable.tsx
+++ b/src/components/table/TasksTable.tsx
@@ -49,6 +49,7 @@ import {
     useWorker,
 } from '@/hooks/useSyncedState';
 import { compilePath, PATHS } from '@/paths';
+import { AbortFunctionT } from '@/types/CommonTypes';
 import { ComputePlanT } from '@/types/ComputePlansTypes';
 import { TaskT, TaskStatus } from '@/types/TasksTypes';
 
@@ -69,7 +70,7 @@ import TablePagination from '@/components/table/TablePagination';
 
 type TasksTableProps = {
     loading: boolean;
-    list: () => void;
+    list: () => AbortFunctionT;
     tasks: TaskT[];
     count: number;
     computePlan?: ComputePlanT | null;
@@ -96,7 +97,8 @@ const TasksTable = ({
     const setLocationPreserveParams = useSetLocationPreserveParams();
 
     useEffect(() => {
-        list();
+        const abort = list();
+        return abort;
         // The computePlan is needed to trigger a list call once it has been fetched
     }, [
         list,

--- a/src/features/tableFilters/CreatorTableFilter.tsx
+++ b/src/features/tableFilters/CreatorTableFilter.tsx
@@ -28,7 +28,8 @@ const CreatorTableFilter = (): JSX.Element => {
     const { users, fetchUsers } = useUsersStore();
 
     useEffect(() => {
-        fetchUsers({ page, ordering: 'username', match });
+        const abort = fetchUsers({ page, ordering: 'username', match });
+        return abort;
     }, [page, match, fetchUsers]);
 
     const [tmpCreator, onTmpCreatorChange, resetTmpCreator, setTmpCreator] =

--- a/src/routes/compare/Compare.tsx
+++ b/src/routes/compare/Compare.tsx
@@ -31,8 +31,13 @@ const Compare = (): JSX.Element => {
     const { series, fetchingSeries, fetchSeries } = useSeriesStore();
 
     useEffectOnce(() => {
-        fetchComputePlans(keys);
-        fetchSeries(keys);
+        const abortComputePlans = fetchComputePlans(keys);
+        const abortSeries = fetchSeries(keys);
+
+        return () => {
+            abortComputePlans();
+            abortSeries();
+        };
     });
 
     const { context } = usePerfBrowser(

--- a/src/routes/computePlanDetails/workflow/ComputePlanWorkflow.tsx
+++ b/src/routes/computePlanDetails/workflow/ComputePlanWorkflow.tsx
@@ -46,9 +46,11 @@ const ComputePlanWorkflow = (): JSX.Element => {
     }, [key, computePlan?.key, fetchComputePlan]);
 
     useEffect(() => {
+        let abort;
         if (key) {
-            fetchGraph(key);
+            abort = fetchGraph(key);
         }
+        return abort;
     }, [key, fetchGraph]);
 
     if (!key) {

--- a/src/routes/computePlans/ComputePlans.tsx
+++ b/src/routes/computePlans/ComputePlans.tsx
@@ -139,7 +139,8 @@ const ComputePlans = (): JSX.Element => {
     );
 
     useEffect(() => {
-        fetchComputePlans({ page, ordering, ...filters });
+        const abort = fetchComputePlans({ page, ordering, ...filters });
+        return abort;
     }, [fetchComputePlans, page, ordering, filters]);
 
     const { metadata } = useMetadataStore();

--- a/src/routes/datasets/Datasets.tsx
+++ b/src/routes/datasets/Datasets.tsx
@@ -97,7 +97,8 @@ const Datasets = (): JSX.Element => {
         page,
     ]);
     useEffect(() => {
-        fetchDatasets(fetchParams);
+        const abort = fetchDatasets(fetchParams);
+        return abort;
     }, [fetchDatasets, fetchParams]);
 
     const context = useTableFiltersContext('dataset');

--- a/src/routes/functions/Functions.tsx
+++ b/src/routes/functions/Functions.tsx
@@ -75,7 +75,7 @@ const Functions = (): JSX.Element => {
         useFunctionsStore();
 
     useEffect(() => {
-        fetchFunctions({
+        const abort = fetchFunctions({
             page,
             ordering,
             match,
@@ -84,6 +84,7 @@ const Functions = (): JSX.Element => {
             creation_date_before: endOfDay(creationDateBefore),
             can_process: canProcess,
         });
+        return abort;
     }, [
         fetchFunctions,
         page,

--- a/src/routes/users/Users.tsx
+++ b/src/routes/users/Users.tsx
@@ -53,7 +53,8 @@ const Users = (): JSX.Element => {
     useAssetListDocumentTitleEffect('Users', key);
 
     useEffect(() => {
-        fetchUsers({ page, ordering, match });
+        const abort = fetchUsers({ page, ordering, match });
+        return abort;
     }, [page, key, ordering, match, fetchUsers]);
 
     if (userRole !== UserRolesT.admin) {

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -46,3 +46,5 @@ export type APIListArgsT = {
 export type APIRetrieveListArgsT = APIListArgsT & {
     key: string;
 };
+
+export type AbortFunctionT = () => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

When making the change from redux to Zustand in PR #159, we lost the feature to cancel list calls when changing page in the app (although we kept the cancelling on reload). To be clearer, this means you don't want the frontend to finish making a big call to the backend for data concerning page A when you already moved on to page B. This feature is important for better performances in the case of big calls being made in the background for nothing.

Fixes FL-639
