### PR TITLE
fix: Selected CPs now resetting after logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fixed list calls cancelling when reloading or changing page (#200)
+-   Selected CPs not resetting after logout (#203)
 
 ## [0.41.0] - 2023-05-11
 

--- a/src/features/auth/useAuthStore.ts
+++ b/src/features/auth/useAuthStore.ts
@@ -126,6 +126,11 @@ const useAuthStore = create<AuthStateT>((set, get) => ({
         cookies.remove('signature');
         cookies.remove('refresh');
 
+        localStorage.setItem(
+            `${get().info.channel}-selected_compute_plans_`,
+            JSON.stringify([])
+        );
+
         set({ authenticated: false });
         try {
             await getLogOut();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

CPs stay selected in computePlans list page even after logging out. This creates situations where the user don't understand why he has CP selected when he comes back to the app. 
This PR fixes this by resetting the selected CPs after logging out.

Fixes FL-992
