### PR TITLE
feat: change `XAxisMode` when `seriesGroupWithRounds` is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   New icon for list ordering in tables (#191)
 -   CP cancel alert message (#192)
 -   Serialize the performance graph regarding the identifier only (#194)
+-   In perf views, set `round` as default if `seriesGroupWithRounds.length > 0`, otherwise `rank` (#205)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+-   In perf views, set `round` as default if `seriesGroupWithRounds.length > 0`, otherwise `rank` (#205)
+
 ## [0.42.1] - 2023-06-14
 
 ## Fixed
@@ -41,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   New icon for list ordering in tables (#191)
 -   CP cancel alert message (#192)
 -   Serialize the performance graph regarding the identifier only (#194)
--   In perf views, set `round` as default if `seriesGroupWithRounds.length > 0`, otherwise `rank` (#205)
 
 ### Fixed
 

--- a/src/features/perfBrowser/usePerfBrowser.ts
+++ b/src/features/perfBrowser/usePerfBrowser.ts
@@ -262,6 +262,12 @@ const usePerfBrowser = (
         (v) => v
     );
 
+    useEffect(() => {
+        if (seriesGroupsWithRounds.length > 0) {
+            setXAxisMode('round');
+        }
+    }, [seriesGroupsWithRounds.length, setXAxisMode]);
+
     const [yAxisMode, setYAxisMode] = useSyncedState<YAxisModeT>(
         'yAxisMode',
         'linear',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Rounds makes more sense to look at FL performances graph, therefore this PR set `round` as default value if rounds they are available when `seriesGroupWithRounds` is updated (retrieved from backend).

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

Fixes FL-504
-   Think to update CHANGELOG.md before merge if needed !
