### PR TITLE
fix: Hyperparameters bugged display when too big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Creator filter using wrong pagination to fetch users (#201)
 -   Store variable for single assets not resetting correctly before new call (#202)
 -   Selected CPs not resetting after logout (#203)
+-   Hyper-parameters are not nicely shown when their names is too big (#208)
 
 ## [0.41.0] - 2023-05-11
 

--- a/src/components/DrawerSection.tsx
+++ b/src/components/DrawerSection.tsx
@@ -13,6 +13,7 @@ import {
     Tag,
     TagLabel,
     TagRightIcon,
+    Tooltip,
     VStack,
     Code,
 } from '@chakra-ui/react';
@@ -87,9 +88,17 @@ export const DrawerSectionEntry = ({
             {icon}
             {titleStyle === 'code' && <Code fontSize="xs">{title}</Code>}
             {!titleStyle && (
-                <Text whiteSpace="nowrap" width="120px" flexShrink="0">
-                    {capitalize(title)}
-                </Text>
+                <Tooltip label={capitalize(title)}>
+                    <Text
+                        whiteSpace="nowrap"
+                        width="120px"
+                        flexShrink="0"
+                        overflow="hidden"
+                        textOverflow="ellipsis"
+                    >
+                        {capitalize(title)}
+                    </Text>
+                </Tooltip>
             )}
             <Box flexGrow="1" overflowX="hidden">
                 {children}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Hyper-parameters are not nicely shown when their names is too big. This PR fixes display by adding an ellipsis with a tooltip to still be able to read the full name. 
