### PR TITLE
chore: Refactor function field in task

### DIFF
--- a/src/components/table/TasksTable.tsx
+++ b/src/components/table/TasksTable.tsx
@@ -354,7 +354,7 @@ const TasksTable = ({
                                             </Td>
                                             <Td>
                                                 <Text fontSize="sm">
-                                                    {task.function.name}
+                                                    {task.function_name}
                                                 </Text>
                                                 <Text fontSize="xs">
                                                     {`Rank ${task.rank} - ${task.worker}`}

--- a/src/routes/tasks/components/TaskDrawer.tsx
+++ b/src/routes/tasks/components/TaskDrawer.tsx
@@ -15,6 +15,7 @@ import {
 
 import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
 import { compilePath, PATHS } from '@/paths';
+import useFunctionStore from '@/routes/functions/useFunctionStore';
 import TaskOutputsDrawerSection from '@/routes/tasks/components/TaskOutputsDrawerSection';
 
 import DownloadIconButton from '@/components/DownloadIconButton';
@@ -49,6 +50,13 @@ const TaskDrawer = ({
     const { isOpen, onOpen, onClose: onDisclosureClose } = useDisclosure();
 
     const { task, fetchingTask, fetchTask } = useTaskStore();
+    const {
+        function: func,
+        fetchingFunction,
+        fetchFunction,
+    } = useFunctionStore();
+
+    const fetching = fetchingTask || fetchingFunction;
 
     useEffect(() => {
         if (taskKey) {
@@ -58,6 +66,12 @@ const TaskDrawer = ({
             }
         }
     }, [fetchTask, isOpen, onOpen, taskKey]);
+
+    useEffect(() => {
+        if (task) {
+            fetchFunction(task.function_key);
+        }
+    }, [fetchFunction, task]);
 
     useDocumentTitleEffect(
         (setDocumentTitle) => {
@@ -132,7 +146,7 @@ const TaskDrawer = ({
                             organization={task?.owner}
                         />
                         <DrawerSectionEntry title="Compute plan">
-                            {fetchingTask || !task ? (
+                            {fetching || !task || !func ? (
                                 <Skeleton height="4" width="250px" />
                             ) : (
                                 <Link
@@ -151,28 +165,27 @@ const TaskDrawer = ({
                             )}
                         </DrawerSectionEntry>
                         <DrawerSectionEntry title="Function">
-                            {fetchingTask || !task ? (
+                            {fetching || !task || !func ? (
                                 <Skeleton height="4" width="250px" />
                             ) : (
                                 <HStack spacing="2.5">
                                     <Text noOfLines={1}>
                                         <Link
                                             href={compilePath(PATHS.FUNCTION, {
-                                                key: task.function.key,
+                                                key: task.function_key,
                                             })}
                                             color="primary.500"
                                             fontWeight="semibold"
                                             isExternal
                                         >
-                                            {task.function.name}
+                                            {task.function_name}
                                         </Link>
                                     </Text>
                                     <DownloadIconButton
                                         storageAddress={
-                                            task.function.function
-                                                .storage_address
+                                            func?.function.storage_address
                                         }
-                                        filename={`function-${task.function.key}.zip`}
+                                        filename={`function-${task.function_key}.zip`}
                                         aria-label="Download function"
                                         size="xs"
                                         placement="top"
@@ -181,7 +194,7 @@ const TaskDrawer = ({
                             )}
                         </DrawerSectionEntry>
                         <DrawerSectionEntry title="Rank">
-                            {fetchingTask || !task ? (
+                            {fetching || !task || !func ? (
                                 <Skeleton height="4" width="250px" />
                             ) : (
                                 task.rank
@@ -189,12 +202,14 @@ const TaskDrawer = ({
                         </DrawerSectionEntry>
                     </DrawerSection>
                     <TaskInputsDrawerSection
-                        taskLoading={fetchingTask}
+                        loading={fetching}
                         task={task || null}
+                        function={func || null}
                     />
                     <TaskOutputsDrawerSection
-                        taskLoading={fetchingTask}
+                        loading={fetching}
                         task={task || null}
+                        function={func || null}
                     />
                     <MetadataDrawerSection
                         metadata={task?.metadata}

--- a/src/routes/tasks/components/TaskInputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskInputsDrawerSection.tsx
@@ -17,7 +17,7 @@ import { compilePath, PATHS } from '@/paths';
 import { getAssetKindLabel } from '@/routes/functions/FunctionsUtils';
 import { FileT, PermissionsT } from '@/types/CommonTypes';
 import { isDatasetStubT } from '@/types/DatasetTypes';
-import { AssetKindT, FunctionInputT } from '@/types/FunctionsTypes';
+import { AssetKindT, FunctionInputT, FunctionT } from '@/types/FunctionsTypes';
 import { isModelT } from '@/types/ModelsTypes';
 import { TaskInputT, TaskT, TaskIOT } from '@/types/TasksTypes';
 
@@ -398,11 +398,13 @@ const getTaskInputAssets = async (key: string): Promise<TaskIOT[]> => {
 };
 
 const TaskInputsDrawerSection = ({
-    taskLoading,
+    loading,
     task,
+    function: func,
 }: {
-    taskLoading: boolean;
+    loading: boolean;
     task: TaskT | null;
+    function: FunctionT | null;
 }): JSX.Element => {
     const [taskInputsAssets, setTaskInputsAssets] = useState<TaskIOT[]>([]);
 
@@ -422,8 +424,9 @@ const TaskInputsDrawerSection = ({
     return (
         <DrawerSection title="Inputs">
             {task &&
-                !taskLoading &&
-                Object.entries(task.function.inputs).map(
+                func &&
+                !loading &&
+                Object.entries(func.inputs).map(
                     ([identifier, functionInput]) => {
                         const inputs = task.inputs.filter(
                             (input) => input.identifier === identifier

--- a/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
@@ -16,6 +16,7 @@ import {
 import * as TasksApi from '@/api/TasksApi';
 import { getAllPages } from '@/api/request';
 import { getAssetKindLabel } from '@/routes/functions/FunctionsUtils';
+import { FunctionT } from '@/types/FunctionsTypes';
 import { ModelT } from '@/types/ModelsTypes';
 import { TaskT, TaskStatus, TaskIOT } from '@/types/TasksTypes';
 
@@ -23,8 +24,8 @@ import { DrawerSection } from '@/components/DrawerSection';
 
 import DrawerSectionOutModelEntryContent from './DrawerSectionOutModelEntryContent';
 
-const isMultipleOutput = (task: TaskT, output_id: string) => {
-    return task.function.outputs[output_id].multiple;
+const isMultipleOutput = (func: FunctionT, output_id: string) => {
+    return func.outputs[output_id].multiple;
 };
 
 const displayPerformance = (value: number, taskStatus: TaskStatus) => {
@@ -79,11 +80,13 @@ const getTaskOutputsAssets = async (key: string): Promise<TaskIOT[]> => {
 };
 
 const TaskOutputsDrawerSection = ({
-    taskLoading,
+    loading,
     task,
+    function: func,
 }: {
-    taskLoading: boolean;
+    loading: boolean;
     task: TaskT | null;
+    function: FunctionT | null;
 }) => {
     const [taskOutputsAssets, setTaskOutputsAssets] = useState<TaskIOT[]>([]);
 
@@ -108,7 +111,7 @@ const TaskOutputsDrawerSection = ({
                         </Tr>
                     </Thead>
                     <Tbody>
-                        {(taskLoading || !task) &&
+                        {(loading || !task) &&
                             [0, 1, 2].map((key) => (
                                 <Tr key={key}>
                                     <Td paddingLeft="0 !important">
@@ -128,11 +131,12 @@ const TaskOutputsDrawerSection = ({
                                     </Td>
                                 </Tr>
                             ))}
-                        {!taskLoading &&
+                        {!loading &&
                             task &&
+                            func &&
                             taskOutputsAssets.map((output) => {
                                 const multiple = isMultipleOutput(
-                                    task,
+                                    func,
                                     output.identifier
                                 );
                                 return (

--- a/src/types/TasksTypes.ts
+++ b/src/types/TasksTypes.ts
@@ -1,7 +1,7 @@
 import { MetadataT, PermissionT } from './CommonTypes';
 import { DataSampleT } from './DataSampleTypes';
 import { DatasetStubT } from './DatasetTypes';
-import { FunctionT, AssetKindT, FunctionOutputT } from './FunctionsTypes';
+import { AssetKindT, FunctionOutputT } from './FunctionsTypes';
 import { ModelT } from './ModelsTypes';
 import { PerformanceAssetT } from './PerformancesTypes';
 
@@ -87,7 +87,8 @@ export type TaskIOT = DatasetIOT | DatasampleIOT | ModelIOT | PerformanceIOT;
 export type TaskT = {
     key: string;
     creation_date: string;
-    function: FunctionT;
+    function_key: string;
+    function_name: string;
     compute_plan_key: string;
     owner: string;
     metadata: MetadataT;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

We are refactoring function field in ComputeSerializer in the backend to stop embedding the entire function object in task and pass a function_key and a function_name field instead. This brings some changes to the frontend.

Companion PR: https://github.com/Substra/substra-backend/pull/670

Fixes FL-636
