### PR TITLE
fix: Start & end date ordering being reversed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+-   Start & end date ordering being reversed (#210)
+
 ## [0.42.0] - 2023-06-12
 
 ### Added

--- a/src/components/table/TasksTable.tsx
+++ b/src/components/table/TasksTable.tsx
@@ -207,22 +207,22 @@ const TasksTable = ({
                                                 label: 'Start date',
                                                 asc: {
                                                     label: 'Sort start date oldest first',
-                                                    value: '-start_date',
+                                                    value: 'start_date',
                                                 },
                                                 desc: {
                                                     label: 'Sort start date newest first',
-                                                    value: 'start_date',
+                                                    value: '-start_date',
                                                 },
                                             },
                                             {
                                                 label: 'End date',
                                                 asc: {
                                                     label: 'Sort end date oldest first',
-                                                    value: '-end_date',
+                                                    value: 'end_date',
                                                 },
                                                 desc: {
                                                     label: 'Sort end date newest first',
-                                                    value: 'end_date',
+                                                    value: '-end_date',
                                                 },
                                             },
                                             {

--- a/src/routes/computePlans/components/ComputePlanTHead.tsx
+++ b/src/routes/computePlans/components/ComputePlanTHead.tsx
@@ -103,22 +103,22 @@ const ColumnTh = ({ column, onPopoverOpen }: ColumnThProps): JSX.Element => {
                         label: 'Start date',
                         asc: {
                             label: 'Sort start date oldest first',
-                            value: '-start_date',
+                            value: 'start_date',
                         },
                         desc: {
                             label: 'Sort start date newest first',
-                            value: 'start_date',
+                            value: '-start_date',
                         },
                     },
                     {
                         label: 'End date',
                         asc: {
                             label: 'Sort end date oldest first',
-                            value: '-end_date',
+                            value: 'end_date',
                         },
                         desc: {
                             label: 'Sort end date newest first',
-                            value: 'end_date',
+                            value: '-end_date',
                         },
                     },
                     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Start and end date orderings in ComputePlans & Tasks lists was reversed 
