### PR TITLE
fix: Users list skeleton flashing when opening/closing drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Remove pagination on `get_performances` to remove limitation on 1000 first points (#222)
 -   Page title now updated properly when opening a user drawer (#218)
+-   Users list skeleton no longer flashing when opening/closing drawer (#213)
 
 ## [0.43.0] - 2023-06-27
 

--- a/src/routes/users/Users.tsx
+++ b/src/routes/users/Users.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import {
     Box,
@@ -45,6 +45,10 @@ const Users = (): JSX.Element => {
     const [ordering] = useOrdering('username');
 
     const { users, usersCount, fetchingUsers, fetchUsers } = useUsersStore();
+    const fetchUsersList = useCallback(
+        () => fetchUsers({ page, ordering, match }),
+        [page, ordering, match, fetchUsers]
+    );
     const {
         info: { user_role: userRole },
     } = useAuthStore();
@@ -53,9 +57,9 @@ const Users = (): JSX.Element => {
     useAssetListDocumentTitleEffect('Users', key);
 
     useEffect(() => {
-        const abort = fetchUsers({ page, ordering, match });
+        const abort = fetchUsersList();
         return abort;
-    }, [page, key, ordering, match, fetchUsers]);
+    }, [fetchUsersList]);
 
     if (userRole !== UserRolesT.admin) {
         return <NotFound />;
@@ -69,7 +73,7 @@ const Users = (): JSX.Element => {
             spacing="2.5"
             alignItems="flex-start"
         >
-            <UserDrawer />
+            <UserDrawer fetchUsersList={fetchUsersList} />
             <TableTitle title="Users" />
             <HStack width="100%" spacing="2.5" justify="space-between">
                 <SearchBar placeholder="Search username..." />

--- a/src/routes/users/components/CreateUserForm.tsx
+++ b/src/routes/users/components/CreateUserForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@chakra-ui/react';
 
 import { useToast } from '@/hooks/useToast';
+import { AbortFunctionT } from '@/types/CommonTypes';
 import { UserRolesT } from '@/types/UsersTypes';
 
 import DrawerHeader from '@/components/DrawerHeader';
@@ -21,8 +22,10 @@ import UsernameInput from './UsernameInput';
 
 const CreateUserForm = ({
     closeHandler,
+    fetchUsersList,
 }: {
     closeHandler: () => void;
+    fetchUsersList: () => AbortFunctionT;
 }): JSX.Element => {
     const toast = useToast();
 
@@ -51,6 +54,7 @@ const CreateUserForm = ({
                     status: 'success',
                     isClosable: true,
                 });
+                fetchUsersList();
                 closeHandler();
             } else {
                 toast({

--- a/src/routes/users/components/UpdateUserForm.tsx
+++ b/src/routes/users/components/UpdateUserForm.tsx
@@ -25,6 +25,7 @@ import { RiDeleteBinLine } from 'react-icons/ri';
 import * as UsersApi from '@/api/UsersApi';
 import { useToast } from '@/hooks/useToast';
 import { compilePath, PATHS } from '@/paths';
+import { AbortFunctionT } from '@/types/CommonTypes';
 import { UserRolesT } from '@/types/UsersTypes';
 
 import DrawerHeader from '@/components/DrawerHeader';
@@ -35,9 +36,11 @@ import RoleInput from './RoleInput';
 
 const UpdateUserForm = ({
     closeHandler,
+    fetchUsersList,
     username,
 }: {
     closeHandler: () => void;
+    fetchUsersList: () => AbortFunctionT;
     username: string;
 }): JSX.Element => {
     const toast = useToast();
@@ -75,7 +78,6 @@ const UpdateUserForm = ({
                     status: 'success',
                     isClosable: true,
                 });
-
                 closeHandler();
             } else {
                 toast({
@@ -103,7 +105,7 @@ const UpdateUserForm = ({
                 status: 'success',
                 isClosable: true,
             });
-
+            fetchUsersList();
             closeHandler();
         } else {
             toast({
@@ -209,6 +211,7 @@ const UpdateUserForm = ({
                 size="sm"
                 closeOnEsc={!deletingUser}
                 closeOnOverlayClick={!deletingUser}
+                blockScrollOnMount={false} // this is because of a weird interaction in Chakra when opening an alert when a drawer is opened
                 isCentered
             >
                 <AlertDialogOverlay>

--- a/src/routes/users/components/UserDrawer.tsx
+++ b/src/routes/users/components/UserDrawer.tsx
@@ -6,11 +6,16 @@ import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
 import useKeyFromPath from '@/hooks/useKeyFromPath';
 import { useSetLocationPreserveParams } from '@/hooks/useLocationWithParams';
 import { PATHS } from '@/paths';
+import { AbortFunctionT } from '@/types/CommonTypes';
 
 import CreateUserForm from './CreateUserForm';
 import UpdateUserForm from './UpdateUserForm';
 
-const UserDrawer = (): JSX.Element => {
+const UserDrawer = ({
+    fetchUsersList,
+}: {
+    fetchUsersList: () => AbortFunctionT;
+}): JSX.Element => {
     const setLocationPreserveParams = useSetLocationPreserveParams();
     const { isOpen, onOpen, onClose } = useDisclosure();
     const username = useKeyFromPath(PATHS.USER);
@@ -48,11 +53,15 @@ const UserDrawer = (): JSX.Element => {
         >
             <DrawerOverlay />
             {username === 'create' && (
-                <CreateUserForm closeHandler={closeHandler} />
+                <CreateUserForm
+                    closeHandler={closeHandler}
+                    fetchUsersList={fetchUsersList}
+                />
             )}
             {!!username && username !== 'create' && (
                 <UpdateUserForm
                     closeHandler={closeHandler}
+                    fetchUsersList={fetchUsersList}
                     username={username || ''}
                 />
             )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Fixes an error where the skeleton for the Users list was flashing each time we opened or closed the user drawer. This is because we used to refetch the list of users every time to check if a user had been created, deleted or updated. We now only fetch in the case of a creation or deletion. Updates are handled in the store directly and closing without actions or opening drawer no longer triggers a list fetch.

Fixes FL-1035
