### PR TITLE
fix: switch `task_execution` and `save_outputs` in `TaskStep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   In perf views, set `round` as default if `seriesGroupWithRounds.length > 0`, otherwise `rank` (#205)
 
+## Fixed
+
+-   Task execution and output saving duration being switched (#214)
+
 ## [0.42.1] - 2023-06-14
 
 ## Fixed

--- a/src/types/TasksTypes.ts
+++ b/src/types/TasksTypes.ts
@@ -107,8 +107,8 @@ export type TaskT = {
 export enum TaskStep {
     imageBuilding = 'build_image',
     inputsPreparation = 'prepare_inputs',
-    taskExecution = 'save_outputs',
-    outputsSaving = 'task_execution',
+    taskExecution = 'task_execution',
+    outputsSaving = 'save_outputs',
 }
 
 export type StepInfoT = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Currently, we represent task execution duration time as saving output time and reciprocally. This mislead users to think that there is a bug and that saving output is much slower than actually computing stuff, however this is not the case.

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

Fixes FL-570
