### PR TITLE
chore: release 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+## [0.43.0] - 2023-06-27
+
+### Changed
 
 -   In perf views, set `round` as default if `seriesGroupWithRounds.length > 0`, otherwise `rank` (#205)
 
-## Fixed
+### Fixed
 
 -   Task execution and output saving duration being switched (#214)
 
 ## [0.42.1] - 2023-06-14
 
-## Fixed
+### Fixed
 
 -   Start & end date ordering being reversed (#210)
 

--- a/charts/substra-frontend/CHANGELOG.md
+++ b/charts/substra-frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.20
+
+### Changed
+
+- Upgraded AppVersion to 0.43.0
+
 ## 1.0.19
 
 ### Changed

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -13,6 +13,6 @@ maintainers:
     - name: Substra Team
       email: support@substra.org
 
-version: 1.0.19
-appVersion: 0.42.1 # should be same as in package.json
+version: 1.0.20
+appVersion: 0.43.0 # should be same as in package.json
 kubeVersion: '>= 1.19.0-0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "substra-frontend",
-    "version": "0.42.1",
+    "version": "0.43.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "substra-frontend",
-            "version": "0.42.1",
+            "version": "0.43.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@chakra-ui/react": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "license": "Apache-2.0",
     "private": "true",
-    "version": "0.42.1",
+    "version": "0.43.0",
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",


### PR DESCRIPTION
## [0.43.0] - 2023-06-27

### Changed

-   In perf views, set `round` as default if `seriesGroupWithRounds.length > 0`, otherwise `rank` (#205)

### Fixed

-   Task execution and output saving duration being switched (#214)