### PR TITLE
fix: Ranks being unselectable in CP performances

### DIFF
--- a/src/features/perfBrowser/usePerfBrowser.ts
+++ b/src/features/perfBrowser/usePerfBrowser.ts
@@ -266,7 +266,8 @@ const usePerfBrowser = (
         if (seriesGroupsWithRounds.length > 0) {
             setXAxisMode('round');
         }
-    }, [seriesGroupsWithRounds.length, setXAxisMode]);
+        //eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [seriesGroupsWithRounds.length]);
 
     const [yAxisMode, setYAxisMode] = useSyncedState<YAxisModeT>(
         'yAxisMode',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Fix for a bug where X Axis for the CP performances graphs kept going back to rounds even after selecting ranks.