### PR TITLE
fix: Document title when user drawer is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Remove pagination on `get_performances` to remove limitation on 1000 first points (#222)
+-   Page title now updated properly when opening a user drawer (#218)
 
 ## [0.43.0] - 2023-06-27
 

--- a/src/routes/users/components/UserDrawer.tsx
+++ b/src/routes/users/components/UserDrawer.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { Drawer, useDisclosure, DrawerOverlay } from '@chakra-ui/react';
 
+import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
 import useKeyFromPath from '@/hooks/useKeyFromPath';
 import { useSetLocationPreserveParams } from '@/hooks/useLocationWithParams';
 import { PATHS } from '@/paths';
@@ -24,6 +25,18 @@ const UserDrawer = (): JSX.Element => {
         setLocationPreserveParams(PATHS.USERS);
         onClose();
     };
+
+    const key = useKeyFromPath(PATHS.USER);
+    useDocumentTitleEffect(
+        (setDocumentTitle) => {
+            if (key === 'create') {
+                setDocumentTitle('User creation');
+            } else if (key) {
+                setDocumentTitle(`Update ${key}`);
+            }
+        },
+        [key]
+    );
 
     return (
         <Drawer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Page title (title visible in the browser tab) wasn't updated when opening the user drawer

Fixes FL-1096
