### PR TITLE
fix: return all performances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Update cypress and old e2e architecture & tests (#219)
 
+### Fixed
+
+-   Remove pagination on `get_performances` to remove limitation on 1000 first points (#222)
+
 ## [0.43.0] - 2023-06-27
 
 ### Changed

--- a/src/api/ComputePlansApi.ts
+++ b/src/api/ComputePlansApi.ts
@@ -48,14 +48,14 @@ export const listComputePlanTasks = (
     );
 };
 
-type PaginatedPerformanceResponseT = {
+type PerformanceResponseT = {
     results: PerformanceT[];
     compute_plan_statistics: ComputePlanStatisticsT;
 };
 export const listComputePlanPerformances = (
     { key, ...apiListArgs }: APIRetrieveListArgsT,
     config: AxiosRequestConfig
-): AxiosPromise<PaginatedPerformanceResponseT> => {
+): AxiosPromise<PerformanceResponseT> => {
     return API.authenticatedGet(
         compilePath(API_PATHS.COMPUTE_PLAN_PERFORMANCES, { key }),
         {

--- a/src/api/ComputePlansApi.ts
+++ b/src/api/ComputePlansApi.ts
@@ -48,7 +48,8 @@ export const listComputePlanTasks = (
     );
 };
 
-type PaginatedPerformanceResponseT = PaginatedApiResponseT<PerformanceT> & {
+type PaginatedPerformanceResponseT = {
+    results: PerformanceT[];
     compute_plan_statistics: ComputePlanStatisticsT;
 };
 export const listComputePlanPerformances = (

--- a/src/features/series/useSeriesStore.tsx
+++ b/src/features/series/useSeriesStore.tsx
@@ -29,8 +29,6 @@ const getComputePlanSeries = async (
         const response = await listComputePlanPerformances(
             {
                 key: computePlanKey,
-                pageSize: 0,
-                page: 1,
             },
             { signal }
         );


### PR DESCRIPTION
## Related issues

- https://github.com/Substra/substra/pull/372
- https://github.com/Substra/substra-backend/pull/690

## Description

Remove pagination in performance endpoints, as we always need all of them. (cf linear description)

Note: alternative implementation would be to iterate on all pages in `<task_id>/perf/` in all case,  in the frontend and in the SDK.

Fixes FL-1092

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

-   Think to update CHANGELOG.md before merge if needed !
