### PR TITLE
fix: e2e tests path in dockerfile

### DIFF
--- a/docker/substra-frontend-tests/Dockerfile
+++ b/docker/substra-frontend-tests/Dockerfile
@@ -1,6 +1,6 @@
-FROM cypress/included:7.6.0
+FROM cypress/included:12.12.0
 
 RUN mkdir /e2e
 COPY /e2e-tests/cypress /e2e/cypress
-COPY /e2e-tests/cypress.json /e2e/cypress.json
+COPY /e2e-tests/cypress.config.ts /e2e/cypress.config.ts
 #ENV DEBUG="cypress:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

CI is failing because e2e tests config file path has changed and was not updated in Dockerfile.
