### PR TITLE
fix(docker/e2e): add typescript in docker image

### DIFF
--- a/docker/substra-frontend-tests/Dockerfile
+++ b/docker/substra-frontend-tests/Dockerfile
@@ -1,6 +1,9 @@
 FROM cypress/included:12.12.0
 
-RUN mkdir /e2e
+RUN yarn add typescript@4.4.4
+
+WORKDIR /e2e
+
 COPY /e2e-tests/cypress /e2e/cypress
 COPY /e2e-tests/cypress.config.ts /e2e/cypress.config.ts
 #ENV DEBUG="cypress:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

### Issue

```js
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /e2e/cypress.config.ts
```

https://github.com/Substra/substra-frontend/pull/225#issuecomment-1642142034

### Proof of Concept

```bash
$ docker build -t frontend-e2e -f docker/substra-frontend-tests/Dockerfile . && docker run -it --rm frontend-e2e
```

```bash
DevTools listening on ws://127.0.0.1:38653/devtools/browser/accec9b0-e84d-440c-9c65-1ccbc602cb7f
[453:0720/061528.900174:ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.
Couldn't find tsconfig.json. tsconfig-paths will be skipped
Cypress could not verify that this server is running:

  > http://substra-frontend.org-1.com:3000

We are verifying this server because it has been configured as your baseUrl.

Cypress automatically waits until your server is accessible before running tests.

We will try connecting to it 3 more times...
We will try connecting to it 2 more times...
We will try connecting to it 1 more time...

Cypress failed to verify that your server is running.

Please start this server and then run Cypress again.
```

### Results

<img width="719" alt="image" src="https://github.com/Substra/substra-frontend/assets/135698225/1902200f-dd89-4ab1-8263-a5a6ec366818">

<!--- Describe your choices and changes in detail -->

