### PR TITLE
feat: Add clearer ui for asset download permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Reload current asset list on nav tab click (#206)
+-   Clearer UI for asset download permissions (#228)
 
 ### Changed
 

--- a/src/routes/dataset/Dataset.tsx
+++ b/src/routes/dataset/Dataset.tsx
@@ -1,13 +1,13 @@
-import React, { Suspense, useEffect, useMemo } from 'react';
+import React, { Suspense, useEffect } from 'react';
 
 import { useRoute } from 'wouter';
 
 import { Box, Flex, Heading, HStack, VStack, Text } from '@chakra-ui/react';
 
-import useAuthStore from '@/features/auth/useAuthStore';
 import CopyIconButton from '@/features/copy/CopyIconButton';
 import useUpdateAssetName from '@/features/updateAsset/useUpdateAssetName';
 import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
+import useHasPermission from '@/hooks/useHasPermission';
 import { PATHS } from '@/paths';
 import MoreMenu from '@/routes/dataset/components/MoreMenu';
 
@@ -40,18 +40,8 @@ const Dataset = (): JSX.Element => {
         fetchOpener,
         updateDataset,
     } = useDatasetStore();
-    const {
-        info: { organization_id: currentOrganizationId },
-    } = useAuthStore();
 
-    const hasDownloadPermission = useMemo(() => {
-        if (dataset && currentOrganizationId) {
-            return dataset.permissions.download.authorized_ids.includes(
-                currentOrganizationId
-            );
-        }
-        return false;
-    }, [dataset, currentOrganizationId]);
+    const hasDownloadPermission = useHasPermission();
 
     useEffect(() => {
         const fetchAll = async () => {
@@ -183,14 +173,20 @@ const Dataset = (): JSX.Element => {
                                     }
                                     filename="opener.py"
                                     aria-label={
-                                        hasDownloadPermission
+                                        dataset &&
+                                        hasDownloadPermission(
+                                            dataset?.permissions.download
+                                        )
                                             ? 'Download opener'
                                             : "you don't have permission to download this dataset"
                                     }
                                     isDisabled={
-                                        !hasDownloadPermission ||
                                         fetchingOpener ||
-                                        !opener
+                                        !opener ||
+                                        (!!dataset &&
+                                            !hasDownloadPermission(
+                                                dataset?.permissions.download
+                                            ))
                                     }
                                 />
                             </HStack>

--- a/src/routes/dataset/Dataset.tsx
+++ b/src/routes/dataset/Dataset.tsx
@@ -1,9 +1,10 @@
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense, useEffect, useMemo } from 'react';
 
 import { useRoute } from 'wouter';
 
 import { Box, Flex, Heading, HStack, VStack, Text } from '@chakra-ui/react';
 
+import useAuthStore from '@/features/auth/useAuthStore';
 import CopyIconButton from '@/features/copy/CopyIconButton';
 import useUpdateAssetName from '@/features/updateAsset/useUpdateAssetName';
 import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
@@ -39,6 +40,18 @@ const Dataset = (): JSX.Element => {
         fetchOpener,
         updateDataset,
     } = useDatasetStore();
+    const {
+        info: { organization_id: currentOrganizationId },
+    } = useAuthStore();
+
+    const hasDownloadPermission = useMemo(() => {
+        if (dataset && currentOrganizationId) {
+            return dataset.permissions.download.authorized_ids.includes(
+                currentOrganizationId
+            );
+        }
+        return false;
+    }, [dataset, currentOrganizationId]);
 
     useEffect(() => {
         const fetchAll = async () => {
@@ -169,7 +182,16 @@ const Dataset = (): JSX.Element => {
                                             : ''
                                     }
                                     filename="opener.py"
-                                    aria-label="Download opener.py"
+                                    aria-label={
+                                        hasDownloadPermission
+                                            ? 'Download opener'
+                                            : "you don't have permission to download this dataset"
+                                    }
+                                    isDisabled={
+                                        !hasDownloadPermission ||
+                                        fetchingOpener ||
+                                        !opener
+                                    }
                                 />
                             </HStack>
                         </Heading>

--- a/src/routes/functions/components/FunctionDrawer.tsx
+++ b/src/routes/functions/components/FunctionDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 
 import {
     Drawer,
@@ -9,9 +9,9 @@ import {
     VStack,
 } from '@chakra-ui/react';
 
-import useAuthStore from '@/features/auth/useAuthStore';
 import useUpdateAssetName from '@/features/updateAsset/useUpdateAssetName';
 import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
+import useHasPermission from '@/hooks/useHasPermission';
 import useKeyFromPath from '@/hooks/useKeyFromPath';
 import { useSetLocationPreserveParams } from '@/hooks/useLocationWithParams';
 import { PATHS } from '@/paths';
@@ -46,18 +46,8 @@ const FunctionDrawer = (): JSX.Element => {
         fetchDescription,
         updateFunction,
     } = useFunctionStore();
-    const {
-        info: { organization_id: currentOrganizationId },
-    } = useAuthStore();
 
-    const hasDownloadPermission = useMemo(() => {
-        if (func && currentOrganizationId) {
-            return func.permissions.download.authorized_ids.includes(
-                currentOrganizationId
-            );
-        }
-        return false;
-    }, [func, currentOrganizationId]);
+    const hasDownloadPermission = useHasPermission();
 
     useEffect(() => {
         if (key) {
@@ -120,14 +110,19 @@ const FunctionDrawer = (): JSX.Element => {
                             }
                             filename={`function-${key}.zip`}
                             aria-label={
-                                hasDownloadPermission
+                                func &&
+                                hasDownloadPermission(
+                                    func?.permissions.download
+                                )
                                     ? 'Download function'
                                     : "You don't have the download permission for this function"
                             }
                             isDisabled={
-                                !hasDownloadPermission ||
                                 fetchingFunction ||
-                                !func
+                                (!!func &&
+                                    !hasDownloadPermission(
+                                        func?.permissions.download
+                                    ))
                             }
                         />
                     }

--- a/src/routes/tasks/components/TaskDrawer.tsx
+++ b/src/routes/tasks/components/TaskDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 
 import {
     Drawer,
@@ -13,8 +13,8 @@ import {
     HStack,
 } from '@chakra-ui/react';
 
-import useAuthStore from '@/features/auth/useAuthStore';
 import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
+import useHasPermission from '@/hooks/useHasPermission';
 import { compilePath, PATHS } from '@/paths';
 import TaskOutputsDrawerSection from '@/routes/tasks/components/TaskOutputsDrawerSection';
 
@@ -50,18 +50,8 @@ const TaskDrawer = ({
     const { isOpen, onOpen, onClose: onDisclosureClose } = useDisclosure();
 
     const { task, fetchingTask, fetchTask } = useTaskStore();
-    const {
-        info: { organization_id: currentOrganizationId },
-    } = useAuthStore();
 
-    const hasFunctionDownloadPermission = useMemo(() => {
-        if (task?.function && currentOrganizationId) {
-            return task.function.permissions.download.authorized_ids.includes(
-                currentOrganizationId
-            );
-        }
-        return false;
-    }, [task, currentOrganizationId]);
+    const hasFunctionDownloadPermission = useHasPermission();
 
     useEffect(() => {
         if (taskKey) {
@@ -187,14 +177,20 @@ const TaskDrawer = ({
                                         }
                                         filename={`function-${task.function.key}.zip`}
                                         aria-label={
-                                            hasFunctionDownloadPermission
+                                            hasFunctionDownloadPermission(
+                                                task.function.permissions
+                                                    .download
+                                            )
                                                 ? 'Download function'
                                                 : "You don't have the download permission for this function"
                                         }
                                         size="xs"
                                         placement="top"
                                         isDisabled={
-                                            !hasFunctionDownloadPermission
+                                            !hasFunctionDownloadPermission(
+                                                task.function.permissions
+                                                    .download
+                                            )
                                         }
                                     />
                                 </HStack>

--- a/src/routes/tasks/components/TaskDrawer.tsx
+++ b/src/routes/tasks/components/TaskDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import {
     Drawer,
@@ -13,6 +13,7 @@ import {
     HStack,
 } from '@chakra-ui/react';
 
+import useAuthStore from '@/features/auth/useAuthStore';
 import { useDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
 import { compilePath, PATHS } from '@/paths';
 import TaskOutputsDrawerSection from '@/routes/tasks/components/TaskOutputsDrawerSection';
@@ -49,6 +50,18 @@ const TaskDrawer = ({
     const { isOpen, onOpen, onClose: onDisclosureClose } = useDisclosure();
 
     const { task, fetchingTask, fetchTask } = useTaskStore();
+    const {
+        info: { organization_id: currentOrganizationId },
+    } = useAuthStore();
+
+    const hasFunctionDownloadPermission = useMemo(() => {
+        if (task?.function && currentOrganizationId) {
+            return task.function.permissions.download.authorized_ids.includes(
+                currentOrganizationId
+            );
+        }
+        return false;
+    }, [task, currentOrganizationId]);
 
     useEffect(() => {
         if (taskKey) {
@@ -173,9 +186,16 @@ const TaskDrawer = ({
                                                 .storage_address
                                         }
                                         filename={`function-${task.function.key}.zip`}
-                                        aria-label="Download function"
+                                        aria-label={
+                                            hasFunctionDownloadPermission
+                                                ? 'Download function'
+                                                : "You don't have the download permission for this function"
+                                        }
                                         size="xs"
                                         placement="top"
+                                        isDisabled={
+                                            !hasFunctionDownloadPermission
+                                        }
                                     />
                                 </HStack>
                             )}

--- a/src/routes/tasks/components/TaskInputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskInputsDrawerSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { HStack, Icon, Link, List, Text, Tooltip } from '@chakra-ui/react';
 import {
@@ -12,8 +12,8 @@ import {
 import * as TasksApi from '@/api/TasksApi';
 import { getAllPages } from '@/api/request';
 import AngleIcon from '@/assets/svg/angle-icon.svg';
-import useAuthStore from '@/features/auth/useAuthStore';
 import useCanDownloadModel from '@/hooks/useCanDownloadModel';
+import useHasPermission from '@/hooks/useHasPermission';
 import { compilePath, PATHS } from '@/paths';
 import { getAssetKindLabel } from '@/routes/functions/FunctionsUtils';
 import { FileT, PermissionsT } from '@/types/CommonTypes';
@@ -124,18 +124,7 @@ const OpenerRepresentation = ({
     addressable?: FileT;
     permissions?: PermissionsT;
 }): JSX.Element => {
-    const {
-        info: { organization_id: currentOrganizationId },
-    } = useAuthStore();
-
-    const hasDownloadPermission = useMemo(() => {
-        if (permissions && currentOrganizationId) {
-            return permissions.download.authorized_ids.includes(
-                currentOrganizationId
-            );
-        }
-        return false;
-    }, [permissions, currentOrganizationId]);
+    const hasDownloadPermission = useHasPermission();
 
     return (
         <HStack spacing="2.5" onClick={(e) => e.stopPropagation()}>
@@ -158,13 +147,17 @@ const OpenerRepresentation = ({
                     storageAddress={addressable.storage_address}
                     filename={`opener-${assetKey}.py`}
                     aria-label={
-                        hasDownloadPermission
+                        permissions &&
+                        hasDownloadPermission(permissions.download)
                             ? 'Download opener'
                             : "You don't have the download permission for this dataset"
                     }
                     size="xs"
                     placement="top"
-                    isDisabled={!hasDownloadPermission}
+                    isDisabled={
+                        permissions &&
+                        !hasDownloadPermission(permissions.download)
+                    }
                 />
             )}
         </HStack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Depending on its organisation, a user doesn't always have the permissions to download a function or opener. Currently, the user could still click on the download button when he didn't have the permissions, it's just that nothing would happen.
This PR aims for a clearer UI by disabling the download button and adding an informative tooltip when the user doesn't have permission to download.

Fixes FL-1072
