### PR TITLE
chore: allow running rootless and on readOnlyFileSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Allow production images to run under reduced privileges (#231)
+
 ## [0.44.0] - 2023-07-25
 
 ### Added

--- a/charts/substra-frontend/CHANGELOG.md
+++ b/charts/substra-frontend/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## 1.0.22
+
+### Changed
+
+- Allow the chart to run with reduced capabilities (rootless, readOnlyFileSystem)
+
 ## 1.0.21
 
 ### Changed
 
-- Upgraded AppVersion to 0.44.0
+- Upgrade AppVersion to 0.44.0
 
 ## 1.0.20
 

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -13,6 +13,6 @@ maintainers:
     - name: Substra Team
       email: support@substra.org
 
-version: 1.0.21
+version: 1.0.22
 appVersion: 0.44.0 # should be same as in package.json
 kubeVersion: '>= 1.19.0-0'

--- a/charts/substra-frontend/templates/deployment.yaml
+++ b/charts/substra-frontend/templates/deployment.yaml
@@ -24,17 +24,30 @@ spec:
       serviceAccountName: {{ include "substra-frontend.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: template-html
+          image: "{{ trimSuffix "/" .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: 
+            - 'sh'
+          args:
+            - '-c'
+            - |
+              cp -R /usr/share/nginx/html /
+              envsubst < /html/index-template.html > /html/index.html
+          volumeMounts:
+            - name: html
+              mountPath: /html
+          env:
+            - name: API_URL
+              value: {{ .Values.api.url | quote }}
+            - name: MICROSOFT_CLARITY_ID
+              value: {{ .Values.microsoftClarity.id | quote }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ trimSuffix "/" .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/bash
-          args:
-            - -c
-            - "envsubst < /usr/share/nginx/html/index-template.html > /usr/share/nginx/html/index.html && nginx -g 'daemon off;'"
           ports:
             - name: http
               containerPort: 80
@@ -47,13 +60,22 @@ spec:
             httpGet:
               path: /
               port: http
+          volumeMounts:
+            - name: html
+              mountPath: /usr/share/nginx/html
+            - name: nginx-cache
+              mountPath: /var/cache/nginx/
+            - name: nginx-run
+              mountPath: /var/run
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          env:
-            - name: API_URL
-              value: {{ .Values.api.url | quote }}
-            - name: MICROSOFT_CLARITY_ID
-              value: {{ .Values.microsoftClarity.id | quote }}
+      volumes:
+        - name: html
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {} 
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/substra-frontend/templates/deployment.yaml
+++ b/charts/substra-frontend/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
         - name: template-html
           image: "{{ trimSuffix "/" .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: 
-            - 'sh'
+            - sh
           args:
-            - '-c'
+            - -c
             - |
               cp -R /usr/share/nginx/html /
               envsubst < /html/index-template.html > /html/index.html
@@ -50,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 3000
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen       80;
+    listen       3000;
     server_name  localhost;
     #access_log  /var/log/nginx/host.access.log  main;
     location / {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Changes to our helm chart to allow running on restricted security contexts (rootless, and with `readOnlyFileSystem` set.

Fixes FL-1102

## How to test

Set the values:
```yaml
securityContext:
  capabilities:
    drop:
    - ALL
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 1000
```

with these settings, `skaffold run` fails on `main` but on this branch succeeds

I tried it on the target environment, it seems to work.