### PR TITLE
fix: Cancel CP button unreachable on workflow page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Properly align handles with inputs & outputs in workflow (#229)
+-   Cancel CP button now usable on workflow page (#234)
 
 ## [0.44.0] - 2023-07-25
 

--- a/src/routes/computePlanDetails/components/Actions.tsx
+++ b/src/routes/computePlanDetails/components/Actions.tsx
@@ -79,7 +79,7 @@ const Actions = ({
                         variant="outline"
                         size="xs"
                     />
-                    <MenuList>
+                    <MenuList zIndex="10">
                         {updateNameMenuItem}
                         {cancelComputePlanMenuItem}
                     </MenuList>

--- a/src/routes/computePlanDetails/components/CancelComputePlanMenuItem.tsx
+++ b/src/routes/computePlanDetails/components/CancelComputePlanMenuItem.tsx
@@ -22,13 +22,7 @@ const CancelComputePlanMenuItem = ({
             "This compute plan cannot be canceled because you don't have permission to";
     }
     return (
-        <Tooltip
-            label={label}
-            fontSize="xs"
-            hasArrow
-            placement="bottom-end"
-            shouldWrapChildren
-        >
+        <Tooltip label={label} fontSize="xs" hasArrow placement="bottom-end">
             <MenuItem onClick={onClick} isDisabled>
                 Cancel execution
             </MenuItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

This PR fixes the fact that the cancel compute plan button was unreachable on workflow due to z-index hierarchy. Also remove the "shouldwrapchildren" prop from the tooltip, which made the button only clickable on the text and not its whole width.

Fixes FL-1141
