### PR TITLE
feat: Add duration in task drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Reload current asset list on nav tab click (#206)
 -   Clearer UI for asset download permissions (#228)
+-   Duration displayed in task drawer for all workers (#235)
 
 ### Changed
 

--- a/src/routes/tasks/components/TaskDrawer.tsx
+++ b/src/routes/tasks/components/TaskDrawer.tsx
@@ -27,6 +27,7 @@ import {
     DrawerSectionKeyEntry,
     OrganizationDrawerSectionEntry,
 } from '@/components/DrawerSection';
+import Duration from '@/components/Duration';
 import MetadataDrawerSection from '@/components/MetadataDrawerSection';
 import Status from '@/components/Status';
 import Timing from '@/components/Timing';
@@ -126,7 +127,10 @@ const TaskDrawer = ({
                             {fetchingTask || !task ? (
                                 <Skeleton height="4" width="250px" />
                             ) : (
-                                <Timing asset={task} />
+                                <>
+                                    <Timing asset={task} />
+                                    <Duration asset={task} />
+                                </>
                             )}
                         </DrawerSectionEntry>
                         <OrganizationDrawerSectionEntry


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Add duration in the duration section of the task drawer under the start date & end date.

Fixes FL-1183
