### PR TITLE
fix: color rotation in cp charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Properly align handles with inputs & outputs in workflow (#229)
 -   Cancel CP button now usable on workflow page (#234)
+-   Color rotation on cp charts (#236)
 
 ## [0.44.0] - 2023-07-25
 

--- a/src/features/perfBrowser/usePerfBrowserColors.tsx
+++ b/src/features/perfBrowser/usePerfBrowserColors.tsx
@@ -11,13 +11,13 @@ type ColorDiscriminantProps = {
 export const PERF_BROWSER_COLORSCHEMES = [
     'primary',
     'orange',
-    'blue',
-    'pink',
     'green',
+    'pink',
     'yellow',
     'cyan',
     'red',
     'purple',
+    'blue',
 ];
 
 const usePerfBrowserColors = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

The compute plan charts are using a color rotation for the different lines. Since we changed the primary color when switching to Substra colors, the 1st and 3rd color of the rotation are too similar. This PR switches the order of the rotation so that the similar colors appear less often.

Fixes FL-1186
