### PR TITLE
chore: release 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.0] - 2023-09-05
+
 ### Added
 
 -   Reload current asset list on nav tab click (#206)

--- a/charts/substra-frontend/CHANGELOG.md
+++ b/charts/substra-frontend/CHANGELOG.md
@@ -1,136 +1,142 @@
 # Changelog
 
+## 1.0.23
+
+### Changed
+
+-   Upgrade AppVersion to 0.45.0
+
 ## 1.0.22
 
 ### Changed
 
-- Allow the chart to run with reduced capabilities (rootless, readOnlyFileSystem)
+-   Allow the chart to run with reduced capabilities (rootless, readOnlyFileSystem)
 
 ## 1.0.21
 
 ### Changed
 
-- Upgrade AppVersion to 0.44.0
+-   Upgrade AppVersion to 0.44.0
 
 ## 1.0.20
 
 ### Changed
 
-- Upgraded AppVersion to 0.43.0
+-   Upgraded AppVersion to 0.43.0
 
 ## 1.0.19
 
 ### Changed
 
-- Upgraded AppVersion to 0.42.1
+-   Upgraded AppVersion to 0.42.1
 
 ## 1.0.18
 
 ### Changed
 
-- Upgraded AppVersion to 0.42.0
+-   Upgraded AppVersion to 0.42.0
 
 ## 1.0.17
 
 ### Changed
 
-- Upgraded AppVersion to 0.41.0
+-   Upgraded AppVersion to 0.41.0
 
 ## 1.0.16
 
 ### Changed
 
-- Upgraded AppVersion to 0.40.0
+-   Upgraded AppVersion to 0.40.0
 
 ## 1.0.15
 
 ### Changed
 
-- Upgraded AppVersion to 0.39.2
+-   Upgraded AppVersion to 0.39.2
 
 ## 1.0.14
 
 ### Changed
 
-- Upgraded AppVersion to 0.39.1
+-   Upgraded AppVersion to 0.39.1
 
 ## 1.0.13
 
 ### Changed
 
-- Upgraded AppVersion to 0.39.0
+-   Upgraded AppVersion to 0.39.0
 
 ## 1.0.12
 
 ### Changed
 
-- Update chart maintainers
+-   Update chart maintainers
 
 ## 1.0.11
 
 ### Changed
 
-- Upgraded AppVersion to 0.38.1
+-   Upgraded AppVersion to 0.38.1
 
 ## 1.0.10
 
 ### Changed
 
-- Upgraded AppVersion to 0.38.0
+-   Upgraded AppVersion to 0.38.0
 
 ## 1.0.9
 
 ### Changed
 
-- Upgraded AppVersion to 0.37.0
+-   Upgraded AppVersion to 0.37.0
 
 ## 1.0.8
 
 ### Changed
 
-- Upgraded AppVersion to 0.36.0
+-   Upgraded AppVersion to 0.36.0
 
 ## 1.0.7
 
 ### Changed
 
-- Upgraded AppVersion to 0.35.0
+-   Upgraded AppVersion to 0.35.0
 
 ## 1.0.6
 
 ### Changed
 
-- Upgraded AppVersion to 0.34.0
+-   Upgraded AppVersion to 0.34.0
 
 ## 1.0.5
 
 ### Changed
 
-- Upgraded AppVersion to 0.33.0
+-   Upgraded AppVersion to 0.33.0
 
 ## 1.0.4
 
 ### Changed
 
-- Upgraded AppVersion to 0.32.1
+-   Upgraded AppVersion to 0.32.1
 
 ## 1.0.3
 
 ### Changed
 
-- Upgraded AppVersion to 0.32.0
+-   Upgraded AppVersion to 0.32.0
 
 ## 1.0.2
 
 ### Changed
 
-- Upgraded AppVersion to 0.31.0
+-   Upgraded AppVersion to 0.31.0
 
 ## 1.0.1
 
 ### Changed
 
-- Upgraded AppVersion to 0.30.0
+-   Upgraded AppVersion to 0.30.0
 
 ## 1.0.0
 
@@ -138,4 +144,4 @@
 
 ### Changed
 
-- Set the appVersion field in the chart metadata; the chart will default to using it as a docker tag, if `image.tag` in the values is unset.
+-   Set the appVersion field in the chart metadata; the chart will default to using it as a docker tag, if `image.tag` in the values is unset.

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -13,6 +13,6 @@ maintainers:
     - name: Substra Team
       email: support@substra.org
 
-version: 1.0.22
-appVersion: 0.44.0 # should be same as in package.json
+version: 1.0.23
+appVersion: 0.45.0-rc1 # should be same as in package.json
 kubeVersion: '>= 1.19.0-0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "substra-frontend",
-    "version": "0.44.0",
+    "version": "0.45.0-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "substra-frontend",
-            "version": "0.44.0",
+            "version": "0.45.0-rc1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@chakra-ui/react": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "license": "Apache-2.0",
     "private": "true",
-    "version": "0.44.0",
+    "version": "0.45.0-rc1",
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",


### PR DESCRIPTION
## [0.45.0] - 2023-09-05

### Added

-   Reload current asset list on nav tab click (#206)
-   Clearer UI for asset download permissions (#228)
-   Duration displayed in task drawer for all workers (#235)

### Changed

-   Allow production images to run under reduced privileges (#231)

### Fixed

-   Properly align handles with inputs & outputs in workflow (#229)
-   Cancel CP button now usable on workflow page (#234)
-   Color rotation on cp charts (#236)