### PR TITLE
feat: modify failure report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   LogsModal now use a key so we can use logs not linked with a compute task (#270)
+
 ## [0.46.0] - 2023-10-18
 
 ### Added

--- a/src/routes/tasks/components/ErrorAlert.tsx
+++ b/src/routes/tasks/components/ErrorAlert.tsx
@@ -93,7 +93,11 @@ const ErrorAlert = ({ task }: { task: TaskT }): JSX.Element | null => {
                             </>
                         }
                     />
-                    <LogsModal isOpen={isOpen} onClose={onClose} task={task} />
+                    <LogsModal
+                        isOpen={isOpen}
+                        onClose={onClose}
+                        reportKey={task.function.key}
+                    />
                 </>
             );
         }
@@ -139,7 +143,11 @@ const ErrorAlert = ({ task }: { task: TaskT }): JSX.Element | null => {
                             </>
                         }
                     />
-                    <LogsModal isOpen={isOpen} onClose={onClose} task={task} />
+                    <LogsModal
+                        isOpen={isOpen}
+                        onClose={onClose}
+                        reportKey={task.key}
+                    />
                 </>
             );
         }

--- a/src/routes/tasks/components/LogsModal.tsx
+++ b/src/routes/tasks/components/LogsModal.tsx
@@ -14,7 +14,6 @@ import {
 
 import CopyIconButton from '@/features/copy/CopyIconButton';
 import { API_PATHS, compilePath } from '@/paths';
-import { TaskT } from '@/types/TasksTypes';
 
 import DownloadIconButton from '@/components/DownloadIconButton';
 
@@ -27,16 +26,16 @@ const CodeHighlighter = React.lazy(
 type LogsModalProps = {
     isOpen: boolean;
     onClose: () => void;
-    task: TaskT;
+    reportKey: string;
 };
-const LogsModal = ({ isOpen, onClose, task }: LogsModalProps) => {
+const LogsModal = ({ isOpen, onClose, reportKey }: LogsModalProps) => {
     const initialFocusRef = useRef(null);
 
     const { logs, fetchingLogs, fetchLogs } = useTaskStore();
 
     useEffect(() => {
-        fetchLogs(task.key);
-    }, [fetchLogs, task.key]);
+        fetchLogs(reportKey);
+    }, [fetchLogs, reportKey]);
 
     return (
         <Modal
@@ -73,9 +72,9 @@ const LogsModal = ({ isOpen, onClose, task }: LogsModalProps) => {
                         />
                         <DownloadIconButton
                             storageAddress={compilePath(API_PATHS.LOGS, {
-                                key: task.key,
+                                key: reportKey,
                             })}
-                            filename={`logs_${task.key}`}
+                            filename={`logs_${reportKey}`}
                             aria-label="Download logs"
                             variant="ghost"
                         />


### PR DESCRIPTION
## Companion PR

* orchestrator: https://github.com/Substra/orchestrator/pull/310
* backend: https://github.com/Substra/substra-backend/pull/756
* frontend: https://github.com/Substra/substra-frontend/pull/240
* substra-generator: https://github.com/owkin/substra-generator/pull/131

## Description

Change the `LogsModal` to get a key, allowing to retrieve logs not directly linked with a compute task 

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

Changelog updated
