### PR TITLE
feat: display bundle version in "About" modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Substra bundle version info in the "About" modal (#256)
+
 ## [0.45.1] - 2023-10-06
 
 ### Changed

--- a/src/api/DocsApi.ts
+++ b/src/api/DocsApi.ts
@@ -1,0 +1,9 @@
+import { AxiosPromise } from 'axios';
+
+import { DOCS_API } from '@/api/request';
+import { DOCS_API_PATHS } from '@/paths';
+import { ReleasesInfoT } from '@/types/DocsTypes';
+
+export const retrieveSubstraReleases = (): AxiosPromise<ReleasesInfoT> => {
+    return DOCS_API.get(DOCS_API_PATHS.RELEASES);
+};

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -18,6 +18,17 @@ const CONFIG = {
     },
 };
 
+const CONFIG_DOCS = {
+    baseURL: 'https://docs.substra.org',
+    timeout: 2 * 60 * 1000, // 2 mins
+    headers: {
+        Accept: 'application/json;version=0.0',
+        'Content-Type': 'application/json;',
+    },
+    withCredentials: false,
+};
+const docs_instance = axios.create({ ...CONFIG_DOCS });
+
 const instance = axios.create({ ...CONFIG });
 
 instance.interceptors.request.use((config) => {
@@ -67,6 +78,10 @@ const API = {
     put: instance.put,
     delete: instance.delete,
     anonymousGet: anonymousInstance.get,
+};
+
+export const DOCS_API = {
+    get: docs_instance.get,
 };
 
 export const getApiOptions = ({

--- a/src/components/layout/header/About.tsx
+++ b/src/components/layout/header/About.tsx
@@ -18,6 +18,9 @@ import {
     Link,
     Code,
     Box,
+    Alert,
+    AlertIcon,
+    AlertDescription,
 } from '@chakra-ui/react';
 
 import useAuthStore from '@/features/auth/useAuthStore';
@@ -128,44 +131,70 @@ const About = () => {
                                         <Text>{'Fetching bundle info'}</Text>
                                     </HStack>
                                 ) : (
-                                    <Box>
+                                    <>
                                         {matchingRelease ? (
-                                            <>
-                                                <Text>
-                                                    {`This server is running Substra ${matchingRelease.version}.`}
-                                                </Text>
-                                                <Text>
-                                                    {
-                                                        'In Python, you should use '
-                                                    }
-                                                    <Code fontSize="xs">
-                                                        {`substra==${matchingRelease.components.substra.version}`}
-                                                    </Code>
-                                                    {' and/or '}
-                                                    <Code fontSize="xs">
-                                                        {`substrafl==${matchingRelease.components.substrafl.version}`}
-                                                    </Code>
-                                                    {'.'}
-                                                </Text>
-                                            </>
+                                            <Alert
+                                                status="info"
+                                                alignItems={'center'}
+                                            >
+                                                <AlertIcon />
+                                                <AlertDescription>
+                                                    <Text>
+                                                        {
+                                                            'This server is running Substra '
+                                                        }
+                                                        <Text as="b">
+                                                            {`${matchingRelease.version}`}
+                                                        </Text>
+                                                        {'.'}
+                                                    </Text>
+                                                    <Text>
+                                                        {
+                                                            'In Python, you should use '
+                                                        }
+                                                        <Code fontSize="xs">
+                                                            {`substra==${matchingRelease.components.substra.version}`}
+                                                        </Code>
+                                                        {' and/or '}
+                                                        <Code fontSize="xs">
+                                                            {`substrafl==${matchingRelease.components.substrafl.version}`}
+                                                        </Code>
+                                                        {'.'}
+                                                    </Text>
+                                                </AlertDescription>
+                                            </Alert>
                                         ) : (
-                                            <>
-                                                {
-                                                    'This server is not running a '
-                                                }
-                                                <Link
-                                                    color="black"
-                                                    href="https://docs.substra.org/en/latest/additional/release.html"
-                                                    isExternal
-                                                    textDecoration={'underline'}
-                                                    textUnderlineOffset={3}
-                                                >
-                                                    known Substra release
-                                                </Link>
-                                                {'.'}
-                                            </>
+                                            <Alert
+                                                status="warning"
+                                                alignItems={'center'}
+                                            >
+                                                <AlertIcon />
+                                                <AlertDescription>
+                                                    <Text>
+                                                        {
+                                                            'This server is not running a '
+                                                        }
+
+                                                        <Link
+                                                            color="black"
+                                                            href="https://docs.substra.org/en/latest/additional/release.html"
+                                                            isExternal
+                                                            textDecoration={
+                                                                'underline'
+                                                            }
+                                                            textUnderlineOffset={
+                                                                3
+                                                            }
+                                                        >
+                                                            known Substra
+                                                            release
+                                                        </Link>
+                                                        {'.'}
+                                                    </Text>
+                                                </AlertDescription>
+                                            </Alert>
                                         )}
-                                    </Box>
+                                    </>
                                 )}
                             </Box>
                             <DrawerSection title="Backend">

--- a/src/components/layout/header/About.tsx
+++ b/src/components/layout/header/About.tsx
@@ -50,8 +50,8 @@ const About = () => {
         useState<ReleaseInfoT | null>();
 
     useEffect(() => {
-        if (isOpen) fetchReleasesInfo();
-    }, [isOpen, fetchReleasesInfo]);
+        if (isOpen && releasesInfo === null) fetchReleasesInfo();
+    }, [isOpen, fetchReleasesInfo, releasesInfo]);
 
     useEffect(() => {
         if (releasesInfo && backendVersion && orchestratorVersion) {

--- a/src/features/docs/useReleasesInfoStore.ts
+++ b/src/features/docs/useReleasesInfoStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+
+import { retrieveSubstraReleases } from '@/api/DocsApi';
+import { ReleasesInfoT } from '@/types/DocsTypes';
+
+type ReleasesInfoStateT = {
+    info: ReleasesInfoT | null;
+
+    fetchingInfo: boolean;
+
+    fetchInfo: () => void;
+};
+
+const useReleasesInfoStore = create<ReleasesInfoStateT>((set) => ({
+    info: null,
+    fetchingInfo: true,
+
+    fetchInfo: async () => {
+        set({ fetchingInfo: true });
+        try {
+            const response = await retrieveSubstraReleases();
+            set({
+                fetchingInfo: false,
+                info: response.data,
+            });
+        } catch (error) {
+            console.warn(error);
+            set({ fetchingInfo: false });
+        }
+    },
+}));
+
+export default useReleasesInfoStore;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -54,6 +54,10 @@ export const API_PATHS = {
     WORKFLOW: '/compute_plan/:key/workflow_graph/',
 };
 
+export const DOCS_API_PATHS = {
+    RELEASES: '/en/latest/releases.json',
+};
+
 export function compilePath(
     path: string,
     params: { [key: string]: string }

--- a/src/types/DocsTypes.ts
+++ b/src/types/DocsTypes.ts
@@ -1,0 +1,27 @@
+export type ReleasesInfoT = {
+    components: string[];
+    releases: ReleaseInfoT[];
+};
+
+export type ReleaseInfoT = {
+    version: string;
+    components: {
+        'substra-backend': ComponentReleaseT;
+        'substra-frontend': ComponentReleaseT;
+        orchestrator: ComponentReleaseT;
+        substra: ComponentReleaseT;
+        substrafl: ComponentReleaseT;
+        'substra-tools': ComponentReleaseT;
+    };
+};
+
+type ComponentReleaseT = {
+    version: string;
+    link: string;
+    helm?: HelmReleaseInfoT;
+};
+
+type HelmReleaseInfoT = {
+    version: string;
+    link: string;
+};


### PR DESCRIPTION
## Description

It's often confusing for our partners what version of Substra they are running.

We introduced the "bundle" terminology and showed them [the releases table in the doc](https://docs.substra.org/en/latest/additional/release.html), leading to this workflow:
 - open the "about" modal;
 - check backend version;
 - look for the corresponding bundle release in the table.

This PR simply automates that process by querying https://docs.substra.org/en/latest/releases.json and matching it with the version from the backend `/info` endpoint we already have.

<img width="587" alt="image" src="https://github.com/Substra/substra-frontend/assets/19573328/0dde327f-35c3-47a4-b681-5627d9bdd223">
<img width="588" alt="image" src="https://github.com/Substra/substra-frontend/assets/19573328/6ba54dde-6a1e-4e2d-9ff2-70d5f6acb073">


## How to test

Probably the easiest way is to go into `src/components/layout/header/About.tsx` and just write the values you like for the component versions:

```ts
    // const {
    //     info: {
    //         version: backendVersion,
    //         orchestrator_version: orchestratorVersion,
    //         chaincode_version: chaincodeVersion,
    //     },
    // } = useAuthStore();

    const backendVersion = "0.42.0";
    const orchestratorVersion = "0.36.0";
    const chaincodeVersion = null;
```

## To do

- [x] Ask David about UI
- [x] Update changelog