### PR TITLE
feat: Add e2e tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Permissions details in Task I/Os (#280)
+-   Add e2e tests (#273)
 
 ### Changed
 

--- a/e2e-tests/cypress.config.ts
+++ b/e2e-tests/cypress.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
         BACKEND_API_URL: 'http://substra-backend.org-1.com:8000',
         DEFAULT_PAGE_SIZE: 30,
     },
+    viewportWidth: 1440,
+    viewportHeight: 900,
     video: false,
     defaultCommandTimeout: 20000,
     e2e: {

--- a/e2e-tests/cypress.config.ts
+++ b/e2e-tests/cypress.config.ts
@@ -12,10 +12,21 @@ export default defineConfig({
     video: false,
     defaultCommandTimeout: 20000,
     e2e: {
+        setupNodeEvents(on) {
+            on('task', {
+                // To see log messages in the terminal during cypress run
+                // cy.task("log", "my message")
+                log(message) {
+                    // eslint-disable-next-line no-console
+                    console.log(message + '\n\n');
+                    return null;
+                },
+            });
+        },
         baseUrl: 'http://substra-frontend.org-1.com:3000',
     },
     retries: {
-        runMode: 2,
+        runMode: 0,
         openMode: 0,
     },
 });

--- a/e2e-tests/cypress.config.ts
+++ b/e2e-tests/cypress.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
         baseUrl: 'http://substra-frontend.org-1.com:3000',
     },
     retries: {
-        runMode: 1,
+        runMode: 2,
         openMode: 1,
     },
 });

--- a/e2e-tests/cypress.config.ts
+++ b/e2e-tests/cypress.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
         baseUrl: 'http://substra-frontend.org-1.com:3000',
     },
     retries: {
-        runMode: 0,
-        openMode: 0,
+        runMode: 1,
+        openMode: 1,
     },
 });

--- a/e2e-tests/cypress.config.ts
+++ b/e2e-tests/cypress.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
         USERNAME: 'org-1',
         PASSWORD: 'p@sswr0d44',
         BACKEND_API_URL: 'http://substra-backend.org-1.com:8000',
+        DEFAULT_PAGE_SIZE: 30,
     },
     video: false,
     defaultCommandTimeout: 20000,
@@ -13,6 +14,6 @@ export default defineConfig({
     },
     retries: {
         runMode: 2,
-        openMode: 1,
+        openMode: 0,
     },
 });

--- a/e2e-tests/cypress/e2e/computePlanDetails.cy.js
+++ b/e2e-tests/cypress/e2e/computePlanDetails.cy.js
@@ -14,10 +14,21 @@ describe('Compute plans page', () => {
         cy.url().should('match', /compute_plans\/.{36}\/tasks/);
     });
 
-    it('can add cp to favorites', () => {
+    it('adds cp to favorites', () => {
         cy.getDataCy('favorite-cp').should('not.exist');
         cy.getDataCy('favorite-box').first().click();
         cy.getDataCy('favorite-cp').should('exist');
+    });
+
+    it.only('task drawer shows performance', () => {
+        cy.getDataCy('task-with-performance')
+            .should('have.length.gte', 0)
+            .then(($hits) => {
+                if ($hits.length > 0) {
+                    cy.getDataCy('task-with-performance').first().click();
+                    cy.getDataCy('output-performance').should('exist');
+                }
+            });
     });
 
     it('navigates to the Workflow page', () => {
@@ -26,7 +37,7 @@ describe('Compute plans page', () => {
         cy.getDataCy('workflow-graph').should('exist');
     });
 
-    it('navigates back to the Detail page', () => {
+    it('navigates to the Detail page', () => {
         cy.getDataCy('Details-tab').click({ force: true });
         cy.url().should('match', /compute_plans\/.{36}\/tasks/);
     });

--- a/e2e-tests/cypress/e2e/computePlanDetails.cy.js
+++ b/e2e-tests/cypress/e2e/computePlanDetails.cy.js
@@ -14,6 +14,12 @@ describe('Compute plans page', () => {
         cy.url().should('match', /compute_plans\/.{36}\/tasks/);
     });
 
+    it('can add cp to favorites', () => {
+        cy.getDataCy('favorite-cp').should('not.exist');
+        cy.getDataCy('favorite-box').first().click();
+        cy.getDataCy('favorite-cp').should('exist');
+    });
+
     it('navigates to the Workflow page', () => {
         cy.getDataCy('Workflow-tab').click({ force: true });
         cy.url().should('match', /compute_plans\/.{36}\/workflow/);
@@ -32,7 +38,6 @@ describe('Compute plans page', () => {
     });
 
     it('clicks on perf card to display perf details', () => {
-        // cy.visit('/compute_plans/bb41f602-d644-4191-bec4-3c3f5ccb3d96/tasks/'); // SHOULD NOT HAVE TO DEPEND ON THIS
         cy.getDataCy('Performances-tab').click({ force: true });
         cy.getDataCy('perf-list').should('exist');
         cy.getDataCy('perf-card').first().click();
@@ -40,7 +45,6 @@ describe('Compute plans page', () => {
     });
 
     it('can download perf details as jpeg or csv', () => {
-        // cy.visit('/compute_plans/bb41f602-d644-4191-bec4-3c3f5ccb3d96/tasks/'); // SHOULD NOT HAVE TO DEPEND ON THIS
         cy.getDataCy('Performances-tab').click({ force: true });
         cy.getDataCy('perf-card').first().click();
         cy.get('[data-cpkey]')

--- a/e2e-tests/cypress/e2e/computePlanDetails.cy.js
+++ b/e2e-tests/cypress/e2e/computePlanDetails.cy.js
@@ -1,0 +1,57 @@
+/// <reference types="Cypress" />
+
+describe('Compute plans page', () => {
+    before(() => {
+        cy.login();
+    });
+
+    beforeEach(() => {
+        cy.visit('/compute_plans');
+        cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
+    });
+
+    it('navigates to the dedicated compute plan page', () => {
+        cy.url().should('match', /compute_plans\/.{36}\/tasks/);
+    });
+
+    it('navigates to the Workflow page', () => {
+        cy.getDataCy('Workflow-tab').click({ force: true });
+        cy.url().should('match', /compute_plans\/.{36}\/workflow/);
+        cy.getDataCy('workflow-graph').should('exist');
+    });
+
+    it('navigates back to the Detail page', () => {
+        cy.getDataCy('Details-tab').click({ force: true });
+        cy.url().should('match', /compute_plans\/.{36}\/tasks/);
+    });
+
+    it('navigates to the Performance page', () => {
+        cy.getDataCy('Performances-tab').click({ force: true });
+        cy.url().should('match', /compute_plans\/.{36}\/chart/);
+        cy.getDataCy('cp-chart').should('exist');
+    });
+
+    it('clicks on perf card to display perf details', () => {
+        // cy.visit('/compute_plans/bb41f602-d644-4191-bec4-3c3f5ccb3d96/tasks/'); // SHOULD NOT HAVE TO DEPEND ON THIS
+        cy.getDataCy('Performances-tab').click({ force: true });
+        cy.getDataCy('perf-list').should('exist');
+        cy.getDataCy('perf-card').first().click();
+        cy.getDataCy('perf-details').should('exist');
+    });
+
+    it('can download perf details as jpeg or csv', () => {
+        // cy.visit('/compute_plans/bb41f602-d644-4191-bec4-3c3f5ccb3d96/tasks/'); // SHOULD NOT HAVE TO DEPEND ON THIS
+        cy.getDataCy('Performances-tab').click({ force: true });
+        cy.getDataCy('perf-card').first().click();
+        cy.get('[data-cpkey]')
+            .invoke('data', 'cpkey')
+            .then((key) => {
+                cy.getDataCy('download-button').click();
+                cy.getDataCy('download-as-jpeg').click();
+                cy.checkDownloadedFile(`cp_${key}.jpeg`);
+                cy.getDataCy('download-button').click();
+                cy.getDataCy('download-as-csv').click();
+                cy.checkDownloadedFile(`${key}.csv`);
+            });
+    });
+});

--- a/e2e-tests/cypress/e2e/computePlanDetails.cy.js
+++ b/e2e-tests/cypress/e2e/computePlanDetails.cy.js
@@ -20,7 +20,7 @@ describe('Compute plans page', () => {
         cy.getDataCy('favorite-cp').should('exist');
     });
 
-    it.only('task drawer shows performance', () => {
+    it('task drawer shows performance', () => {
         cy.getDataCy('task-with-performance')
             .should('have.length.gte', 0)
             .then(($hits) => {

--- a/e2e-tests/cypress/e2e/computePlans.cy.js
+++ b/e2e-tests/cypress/e2e/computePlans.cy.js
@@ -15,28 +15,61 @@ describe('Compute plans page', () => {
             .should('have.length.greaterThan', 2);
     });
 
-    it('navigates to the dedicated compute plan page', () => {
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
-        cy.url().should('match', /compute_plans\/.{36}\/tasks/);
+    it('displays tasks count bar in status/task column', () => {
+        cy.get('tbody[data-cy=loaded]')
+            .get('tr')
+            .eq(1)
+            .within(() => {
+                cy.getDataCy('cp-tasks-status')
+                    .should('exist')
+                    .trigger('mouseover');
+                cy.getDataCy('cp-tasks-status-tooltip').should('be.visible');
+            });
     });
 
-    it('navigates to the Workflow page', () => {
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
-        cy.get('[data-cy=Workflow-tab]').click({ force: true });
-        cy.url().should('match', /compute_plans\/.{36}\/workflow/);
-        cy.get('[data-cy=workflow-graph]').should('exist');
+    it('searches CP with a key', () => {
+        cy.get('tbody[data-cy=loaded]').should('exist');
+        cy.getDataCy('items-count').then(($count) => {
+            const count = parseInt($count.text());
+            if (count > Cypress.env('DEFAULT_PAGE_SIZE')) {
+                cy.get('[data-key]')
+                    .first()
+                    .invoke('data', 'key')
+                    .then((key) => {
+                        cy.getDataCy('search-bar').type(key);
+                        cy.getDataCy('search-item').click();
+                        cy.url().should(
+                            'include',
+                            `/compute_plans/${key}/tasks`
+                        );
+                    });
+            }
+        });
     });
 
-    it('navigates back to the Detail page', () => {
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
-        cy.get('[data-cy=Details-tab]').click({ force: true });
-        cy.url().should('match', /compute_plans\/.{36}\/tasks/);
+    it('adds a cp to favorites', () => {
+        cy.getDataCy('favorite-cp').should('not.exist');
+        cy.getDataCy('favorite-box').first().click();
+        cy.getDataCy('favorite-cp').should('exist');
     });
 
-    it('navigates to the Performance page', () => {
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
-        cy.get('[data-cy=Performances-tab]').click({ force: true });
-        cy.url().should('match', /compute_plans\/.{36}\/chart/);
-        cy.get('[data-cy=cp-chart]').should('exist');
+    it('selects/unselects cp in list', () => {
+        cy.getDataCy('selection-popover').should('not.exist');
+        cy.get('[data-cy="selection-box"]>input')
+            .first()
+            .check({ force: true });
+        cy.getDataCy('selection-popover').should('exist');
+        cy.get('[data-cy="selection-box"]>input')
+            .first()
+            .uncheck({ force: true });
+        cy.getDataCy('selection-popover').should('not.exist');
+    });
+
+    it('opens filters', () => {
+        cy.checkOpenFilters(1);
+    });
+
+    it('can filter cps by status', () => {
+        cy.checkFilterAssetsBy('status');
     });
 });

--- a/e2e-tests/cypress/e2e/computePlans.cy.js
+++ b/e2e-tests/cypress/e2e/computePlans.cy.js
@@ -12,7 +12,7 @@ describe('Compute plans page', () => {
     it('lists compute plans', () => {
         cy.get('tbody[data-cy=loaded]')
             .get('tr')
-            .should('have.length.greaterThan', 2);
+            .should('have.length.greaterThan', 1);
     });
 
     it('displays tasks count bar in status/task column', () => {

--- a/e2e-tests/cypress/e2e/computePlans.cy.js
+++ b/e2e-tests/cypress/e2e/computePlans.cy.js
@@ -28,23 +28,7 @@ describe('Compute plans page', () => {
     });
 
     it('searches CP with a key', () => {
-        cy.get('tbody[data-cy=loaded]').should('exist');
-        cy.getDataCy('items-count').then(($count) => {
-            const count = parseInt($count.text());
-            if (count > Cypress.env('DEFAULT_PAGE_SIZE')) {
-                cy.get('[data-key]')
-                    .first()
-                    .invoke('data', 'key')
-                    .then((key) => {
-                        cy.getDataCy('search-bar').type(key);
-                        cy.getDataCy('search-item').click();
-                        cy.url().should(
-                            'include',
-                            `/compute_plans/${key}/tasks`
-                        );
-                    });
-            }
-        });
+        cy.checkSearchByKey('compute_plans');
     });
 
     it('adds a cp to favorites', () => {

--- a/e2e-tests/cypress/e2e/datasets.cy.js
+++ b/e2e-tests/cypress/e2e/datasets.cy.js
@@ -15,8 +15,16 @@ describe('Datasets page', () => {
             .should('have.length.greaterThan', 2);
     });
 
+    it('opens filters', () => {
+        cy.checkOpenFilters(0);
+    });
+
+    it('can filter datasets by owner', () => {
+        cy.checkFilterAssetsBy('owner');
+    });
+
     it('navigates to the dedicated dataset page', () => {
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
+        cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
         cy.url().should('match', /datasets\/.{36}/);
     });
 });

--- a/e2e-tests/cypress/e2e/datasets.cy.js
+++ b/e2e-tests/cypress/e2e/datasets.cy.js
@@ -27,4 +27,8 @@ describe('Datasets page', () => {
         cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
         cy.url().should('match', /datasets\/.{36}/);
     });
+
+    it('searches dataset with a key', () => {
+        cy.checkSearchByKey('datasets');
+    });
 });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -24,4 +24,8 @@ describe('Functions page', () => {
         cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
         cy.get('[data-cy=drawer]').should('exist');
     });
+
+    it('open filters', () => {
+        cy.open_filters();
+    });
 });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -31,12 +31,23 @@ describe('Functions page', () => {
         cy.checkOpenDrawer();
     });
 
-    it('download function', () => {
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
-        cy.getDataCy('download-button').click({ force: true });
-        cy.get('[data-filename]')
-            .invoke('data', 'filename')
-            .then((filename) => cy.checkDownloadedFile(filename));
+    it.only('download function', () => {
+        cy.get('tbody[data-cy=loaded]').then(($body) => {
+            if ($body.find('[data-cy="has-download-permissions"]').length) {
+                cy.getDataCy('has-download-permissions')
+                    .first()
+                    .click({ force: true });
+                cy.getDataCy('download-button').click({ force: true });
+                cy.get('[data-filename]')
+                    .invoke('data', 'filename')
+                    .then((filename) => cy.checkDownloadedFile(filename));
+            } else {
+                cy.task(
+                    'log',
+                    'No function with download permissions available'
+                );
+            }
+        });
     });
 
     // WIP - not working

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -31,7 +31,7 @@ describe('Functions page', () => {
         cy.checkOpenDrawer();
     });
 
-    it.only('download function', () => {
+    it('download function', () => {
         cy.get('tbody[data-cy=loaded]').then(($body) => {
             if ($body.find('[data-cy="has-download-permissions"]').length) {
                 cy.getDataCy('has-download-permissions')
@@ -47,9 +47,6 @@ describe('Functions page', () => {
                         cy.wait('@download');
                         cy.checkDownloadedFile(`function-${fnkey}.zip`);
                     });
-                // cy.get('[data-filename]')
-                //     .invoke('data', 'filename')
-                //     .then((filename) => cy.checkDownloadedFile(filename));
             } else {
                 cy.task(
                     'log',
@@ -57,17 +54,5 @@ describe('Functions page', () => {
                 );
             }
         });
-    });
-
-    // WIP - not working
-    it.skip('copy function key', () => {
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
-        // cy.getDataCy('function-key').invoke('text').as('key');
-        cy.getDataCy('copy-function-key')
-            .click()
-            .invoke('attr', 'value')
-            .then((value) => {
-                cy.checkValueCopiedToClipboard(value);
-            });
     });
 });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -30,4 +30,8 @@ describe('Functions page', () => {
     it('display a function drawer', () => {
         cy.checkOpenDrawer();
     });
+
+    it('searches function with a key', () => {
+        cy.checkSearchByKey('functions');
+    });
 });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -15,6 +15,10 @@ describe('Functions page', () => {
             .should('have.length.greaterThan', 2);
     });
 
+    it('functions pagination', () => {
+        cy.pagination_test();
+    });
+
     it('displays a function drawer', () => {
         cy.get('[data-cy=drawer]').should('not.exist');
         cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -6,12 +6,7 @@ describe('Functions page', () => {
     });
 
     beforeEach(() => {
-        cy.intercept(
-            'GET',
-            `${Cypress.env('BACKEND_API_URL')}/function/?page_size=*`
-        ).as('functions');
         cy.visit('/functions');
-        cy.wait('@functions');
     });
 
     it('lists functions', () => {
@@ -25,14 +20,27 @@ describe('Functions page', () => {
     });
 
     it('open filters', () => {
-        cy.checkOpenFilters();
+        cy.checkOpenFilters(0);
+    });
+
+    it('can filter functions by owner', () => {
+        cy.checkFilterAssetsBy('owner');
     });
 
     it('display a function drawer', () => {
-        cy.checkOpenDrawer('function');
+        cy.checkOpenDrawer();
     });
 
-    it.only('copy function key', () => {
+    it('download function', () => {
+        cy.openDrawer('function');
+        cy.getDataCy('download-button').click({ force: true });
+        cy.get('[data-filename]')
+            .invoke('data', 'filename')
+            .then((filename) => cy.checkDownloadedFile(filename));
+    });
+
+    // WIP - not working
+    it.skip('copy function key', () => {
         cy.openDrawer('function');
         // cy.getDataCy('function-key').invoke('text').as('key');
         cy.getDataCy('copy-function-key')
@@ -41,9 +49,5 @@ describe('Functions page', () => {
             .then((value) => {
                 cy.checkValueCopiedToClipboard(value);
             });
-        // cy.getDataCy('function-key').should(($functionKey) => {
-        //     const key = $functionKey.text();
-        //     cy.checkValueCopiedToClipboard(key);
-        // });
     });
 });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -6,7 +6,12 @@ describe('Functions page', () => {
     });
 
     beforeEach(() => {
+        cy.intercept(
+            'GET',
+            `${Cypress.env('BACKEND_API_URL')}/function/?page_size=*`
+        ).as('functions');
         cy.visit('/functions');
+        cy.wait('@functions');
     });
 
     it('lists functions', () => {
@@ -16,16 +21,29 @@ describe('Functions page', () => {
     });
 
     it('functions pagination', () => {
-        cy.pagination_test();
-    });
-
-    it('displays a function drawer', () => {
-        cy.get('[data-cy=drawer]').should('not.exist');
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
-        cy.get('[data-cy=drawer]').should('exist');
+        cy.paginationTest();
     });
 
     it('open filters', () => {
-        cy.open_filters();
+        cy.checkOpenFilters();
+    });
+
+    it('display a function drawer', () => {
+        cy.checkOpenDrawer('function');
+    });
+
+    it.only('copy function key', () => {
+        cy.openDrawer('function');
+        // cy.getDataCy('function-key').invoke('text').as('key');
+        cy.getDataCy('copy-function-key')
+            .click()
+            .invoke('attr', 'value')
+            .then((value) => {
+                cy.checkValueCopiedToClipboard(value);
+            });
+        // cy.getDataCy('function-key').should(($functionKey) => {
+        //     const key = $functionKey.text();
+        //     cy.checkValueCopiedToClipboard(key);
+        // });
     });
 });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -30,25 +30,4 @@ describe('Functions page', () => {
     it('display a function drawer', () => {
         cy.checkOpenDrawer();
     });
-
-    it.skip('download function', () => {
-        cy.get('tbody[data-cy=loaded]').then(($body) => {
-            if ($body.find('[data-cy="has-download-permissions"]').length) {
-                cy.getDataCy('has-download-permissions')
-                    .first()
-                    .click({ force: true });
-                cy.getDataCy('download-button').click({ force: true });
-                cy.get('[data-fnkey]')
-                    .invoke('data', 'fnkey')
-                    .then((fnkey) => {
-                        cy.checkDownloadedFile(`function-${fnkey}.zip`);
-                    });
-            } else {
-                cy.task(
-                    'log',
-                    'No function with download permissions available'
-                );
-            }
-        });
-    });
 });

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -41,10 +41,6 @@ describe('Functions page', () => {
                 cy.get('[data-fnkey]')
                     .invoke('data', 'fnkey')
                     .then((fnkey) => {
-                        cy.intercept('GET', `/function/${fnkey}/file`).as(
-                            'download'
-                        );
-                        cy.wait('@download');
                         cy.checkDownloadedFile(`function-${fnkey}.zip`);
                     });
             } else {

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -32,7 +32,7 @@ describe('Functions page', () => {
     });
 
     it('download function', () => {
-        cy.openDrawer('function');
+        cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
         cy.getDataCy('download-button').click({ force: true });
         cy.get('[data-filename]')
             .invoke('data', 'filename')
@@ -41,7 +41,7 @@ describe('Functions page', () => {
 
     // WIP - not working
     it.skip('copy function key', () => {
-        cy.openDrawer('function');
+        cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
         // cy.getDataCy('function-key').invoke('text').as('key');
         cy.getDataCy('copy-function-key')
             .click()

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -38,9 +38,18 @@ describe('Functions page', () => {
                     .first()
                     .click({ force: true });
                 cy.getDataCy('download-button').click({ force: true });
-                cy.get('[data-filename]')
-                    .invoke('data', 'filename')
-                    .then((filename) => cy.checkDownloadedFile(filename));
+                cy.get('[data-fnkey]')
+                    .invoke('data', 'fnkey')
+                    .then((fnkey) => {
+                        cy.intercept('GET', `/function/${fnkey}/file`).as(
+                            'download'
+                        );
+                        cy.wait('@download');
+                        cy.checkDownloadedFile(`function-${fnkey}.zip`);
+                    });
+                // cy.get('[data-filename]')
+                //     .invoke('data', 'filename')
+                //     .then((filename) => cy.checkDownloadedFile(filename));
             } else {
                 cy.task(
                     'log',

--- a/e2e-tests/cypress/e2e/functions.cy.js
+++ b/e2e-tests/cypress/e2e/functions.cy.js
@@ -31,7 +31,7 @@ describe('Functions page', () => {
         cy.checkOpenDrawer();
     });
 
-    it('download function', () => {
+    it.skip('download function', () => {
         cy.get('tbody[data-cy=loaded]').then(($body) => {
             if ($body.find('[data-cy="has-download-permissions"]').length) {
                 cy.getDataCy('has-download-permissions')

--- a/e2e-tests/cypress/e2e/menu.cy.js
+++ b/e2e-tests/cypress/e2e/menu.cy.js
@@ -9,7 +9,7 @@ describe('Menu tests', () => {
     });
 
     it('help and feedback modal', () => {
-        cy.getDataCy('help]').click();
+        cy.getDataCy('help').click();
         cy.getDataCy('help-modal').should('exist');
     });
 

--- a/e2e-tests/cypress/e2e/menu.cy.js
+++ b/e2e-tests/cypress/e2e/menu.cy.js
@@ -5,32 +5,43 @@ describe('Menu tests', () => {
 
     beforeEach(() => {
         cy.visit('/compute_plans');
-        cy.get('[data-cy=menu-button]').click();
+        cy.getDataCy('menu-button').click();
     });
 
     it('help and feedback modal', () => {
-        cy.get('[data-cy=help]').click();
-        cy.get('[data-cy=help-modal]').should('exist');
+        cy.getDataCy('help]').click();
+        cy.getDataCy('help-modal').should('exist');
     });
 
     it('about modal', () => {
-        cy.get('[data-cy=about]').click();
-        cy.get('[data-cy=about-modal]').should('exist');
+        cy.getDataCy('about').click();
+        cy.getDataCy('about-modal').should('exist');
     });
 
     it('documentation link', () => {
-        cy.get('[data-cy=documentation]')
+        cy.getDataCy('documentation')
             .should('have.attr', 'href', 'https://docs.substra.org/')
             .should('have.attr', 'target', '_blank');
     });
 
     it('api tokens page', () => {
-        cy.get('[data-cy=api-tokens]').click();
+        cy.getDataCy('api-tokens').click();
         cy.url().should('include', '/manage_tokens');
     });
 
+    it('users management page', () => {
+        cy.get('[data-user-role]')
+            .invoke('data', 'user-role')
+            .then((userRole) => {
+                if (userRole === 'ADMIN') {
+                    cy.getDataCy('users-management').click();
+                    cy.url().should('include', '/users');
+                }
+            });
+    });
+
     it('logout button', () => {
-        cy.get('[data-cy=logout]').click();
+        cy.getDataCy('logout').click();
         cy.url().should('include', '/login');
     });
 });

--- a/e2e-tests/cypress/e2e/tasks.cy.js
+++ b/e2e-tests/cypress/e2e/tasks.cy.js
@@ -31,9 +31,7 @@ describe('Tasks page', () => {
         cy.checkOpenDrawer();
     });
 
-    // WIP
     it('task drawer shows performance', () => {
-        // cy.visit('/tasks?page=123'); // SHOULD NOT HAVE TO DEPEND ON THIS
         cy.getDataCy('task-with-performance').first().click();
         cy.getDataCy('output-performance').should('exist');
     });

--- a/e2e-tests/cypress/e2e/tasks.cy.js
+++ b/e2e-tests/cypress/e2e/tasks.cy.js
@@ -15,9 +15,26 @@ describe('Tasks page', () => {
             .should('have.length.greaterThan', 2);
     });
 
+    it('functions pagination', () => {
+        cy.paginationTest();
+    });
+
+    it('opens filters', () => {
+        cy.checkOpenFilters(0);
+    });
+
+    it('can filter tasks by status', () => {
+        cy.checkFilterAssetsBy('status');
+    });
+
     it('displays a task drawer', () => {
-        cy.get('[data-cy=drawer]').should('not.exist');
-        cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
-        cy.get('[data-cy=drawer]').should('exist');
+        cy.checkOpenDrawer();
+    });
+
+    // WIP
+    it('task drawer shows performance', () => {
+        // cy.visit('/tasks?page=123'); // SHOULD NOT HAVE TO DEPEND ON THIS
+        cy.getDataCy('task-with-performance').first().click();
+        cy.getDataCy('output-performance').should('exist');
     });
 });

--- a/e2e-tests/cypress/e2e/users.cy.js
+++ b/e2e-tests/cypress/e2e/users.cy.js
@@ -1,0 +1,51 @@
+describe('Users page', () => {
+    before(() => {
+        cy.login();
+    });
+
+    beforeEach(() => {
+        cy.visit('/compute_plans');
+        cy.getDataCy('menu-button').click();
+        cy.get('[data-user-role]')
+            .invoke('data', 'user-role')
+            .then((userRole) => {
+                if (userRole === 'ADMIN') {
+                    cy.visit('/users');
+                }
+            });
+    });
+
+    it('can create user', () => {
+        cy.getDataCy('create-user').click();
+        cy.getDataCy('username-input').type('Test');
+        cy.getDataCy('password-input').type('Azertyuiop123456789$');
+        cy.getDataCy('submit-form').click();
+
+        cy.get('[data-name="Test"]').first().should('exist');
+    });
+
+    it('can update user', () => {
+        cy.get('[data-name="Test"]')
+            .first()
+            .should('exist')
+            .then(($el) => {
+                cy.wrap($el).should('have.data', 'role', 'USER');
+                cy.wrap($el).click();
+            });
+        cy.get('select').eq(0).select('ADMIN');
+        cy.getDataCy('submit-form').click();
+
+        cy.get('[data-name="Test"]')
+            .first()
+            .then(($el) => {
+                cy.wrap($el).should('have.data', 'role', 'ADMIN');
+            });
+    });
+
+    it('can delete user', () => {
+        cy.get('[data-name="Test"]').first().click();
+        cy.getDataCy('delete-user').click();
+        cy.getDataCy('confirm-delete').click();
+        cy.get('[data-name="Test"]').should('not.exist');
+    });
+});

--- a/e2e-tests/cypress/e2e/users.cy.js
+++ b/e2e-tests/cypress/e2e/users.cy.js
@@ -35,6 +35,7 @@ describe('Users page', () => {
         cy.get('select').eq(0).select('ADMIN');
         cy.getDataCy('submit-form').click();
 
+        cy.wait(500);
         cy.get('[data-name="Test"]')
             .first()
             .then(($el) => {

--- a/e2e-tests/cypress/e2e/users.cy.js
+++ b/e2e-tests/cypress/e2e/users.cy.js
@@ -35,11 +35,10 @@ describe('Users page', () => {
         cy.get('select').eq(0).select('ADMIN');
         cy.getDataCy('submit-form').click();
 
-        cy.wait(500);
         cy.get('[data-name="Test"]')
             .first()
-            .then(($el) => {
-                cy.wrap($el).should('have.data', 'role', 'ADMIN');
+            .should(($el) => {
+                expect($el).to.have.data('role', 'ADMIN');
             });
     });
 

--- a/e2e-tests/cypress/fixtures/example.json
+++ b/e2e-tests/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-    "name": "Using fixtures to represent data",
-    "email": "hello@cypress.io",
-    "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -40,6 +40,23 @@ Cypress.Commands.add('login', () => {
                 cy.getCookie('signature').should('not.be.null');
                 cy.getCookie('header.payload').should('not.be.null');
             },
+            cacheAcrossSpecs: true,
         }
     );
+});
+
+Cypress.Commands.add('pagination_test', () => {
+    cy.get('[data-cy=items-count]').then(($count) => {
+        const count = parseInt($count.text());
+        if (count > Cypress.env('DEFAULT_PAGE_SIZE')) {
+            cy.log('wtfffdfsghjerzinfgioejfeiozfjiozpqg');
+            cy.get('[data-cy=active-page').invoke('text').should('eq', '1');
+            cy.get('[data-cy=next-page]').click();
+            cy.get('[data-cy=active-page').invoke('text').should('eq', '2');
+            cy.get('[data-cy=previous-page]').click();
+            cy.get('[data-cy=active-page').invoke('text').should('eq', '1');
+            cy.get('[data-cy=second-page]').click();
+            cy.get('[data-cy=active-page').invoke('text').should('eq', '2');
+        }
+    });
 });

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -24,6 +24,10 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
+Cypress.Commands.add('getDataCy', (input) => {
+    return cy.get(`[data-cy='${input}']`);
+});
+
 Cypress.Commands.add('login', () => {
     cy.session(
         'login',
@@ -45,22 +49,48 @@ Cypress.Commands.add('login', () => {
     );
 });
 
-Cypress.Commands.add('pagination_test', () => {
-    cy.get('[data-cy=items-count]').then(($count) => {
+Cypress.Commands.add('paginationTest', () => {
+    cy.getDataCy('items-count').then(($count) => {
         const count = parseInt($count.text());
         if (count > Cypress.env('DEFAULT_PAGE_SIZE')) {
-            cy.get('[data-cy=active-page').invoke('text').should('eq', '1');
-            cy.get('[data-cy=next-page]').click();
-            cy.get('[data-cy=active-page').invoke('text').should('eq', '2');
-            cy.get('[data-cy=previous-page]').click();
-            cy.get('[data-cy=active-page').invoke('text').should('eq', '1');
-            cy.get('[data-cy=second-page]').click();
-            cy.get('[data-cy=active-page').invoke('text').should('eq', '2');
+            cy.getDataCy('active-page').invoke('text').should('eq', '1');
+            cy.getDataCy('next-page').click();
+            cy.getDataCy('active-page').invoke('text').should('eq', '2');
+            cy.getDataCy('previous-page').click();
+            cy.getDataCy('active-page').invoke('text').should('eq', '1');
+            cy.getDataCy('second-page').click();
+            cy.getDataCy('active-page').invoke('text').should('eq', '2');
         }
     });
 });
 
-Cypress.Commands.add('open_filters', () => {
-    cy.get('[data-cy=open-filters]').click();
-    cy.get('[data-cy=filters-table]').should('exist');
+Cypress.Commands.add('openFilters', () => {
+    cy.getDataCy('open-filters').click();
+});
+
+Cypress.Commands.add('checkOpenFilters', () => {
+    cy.openFilters();
+    cy.getDataCy('filters-table').should('exist');
+});
+
+Cypress.Commands.add('openDrawer', (route) => {
+    cy.intercept('GET', `${Cypress.env('BACKEND_API_URL')}/${route}/*/`).as(
+        'drawer'
+    );
+    cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
+    cy.wait('@drawer');
+});
+
+Cypress.Commands.add('checkOpenDrawer', (route) => {
+    cy.getDataCy('drawer').should('not.exist');
+    cy.openDrawer(route);
+    cy.getDataCy('drawer').should('exist');
+});
+
+Cypress.Commands.add('checkValueCopiedToClipboard', (value) => {
+    cy.window().then((win) => {
+        win.navigator.clipboard.readText().then((text) => {
+            expect(text).to.eq(value);
+        });
+    });
 });

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -64,29 +64,38 @@ Cypress.Commands.add('paginationTest', () => {
     });
 });
 
-Cypress.Commands.add('openFilters', () => {
-    cy.getDataCy('open-filters').click();
-});
-
-Cypress.Commands.add('checkOpenFilters', () => {
-    cy.openFilters();
+Cypress.Commands.add('checkOpenFilters', (position) => {
+    cy.getDataCy('filters-table').should('not.exist');
+    cy.getDataCy('add-filter').click();
     cy.getDataCy('filters-table').should('exist');
+    cy.getDataCy('close-filters-modal').click();
+    cy.getDataCy('filters-table').should('not.be.visible');
+    cy.getDataCy('th-menu-button').eq(position).click();
+    cy.getDataCy('open-filters').first().click();
+    cy.getDataCy('filters-table').should('be.visible');
 });
 
-Cypress.Commands.add('openDrawer', (route) => {
-    cy.intercept('GET', `${Cypress.env('BACKEND_API_URL')}/${route}/*/`).as(
-        'drawer'
-    );
-    cy.get('tbody[data-cy=loaded]').get('tr').eq(2).click({ force: true });
-    cy.wait('@drawer');
+Cypress.Commands.add('checkFilterAssetsBy', (filter) => {
+    cy.getDataCy('add-filter').click();
+    cy.getDataCy(`${filter}-filters`).click();
+    cy.get('[data-cy="filter-checkbox"] > input')
+        .first()
+        .check({ force: true });
+    cy.getDataCy('filters-apply').click();
+    cy.getDataCy(`${filter}-filter-tag`).should('exist');
 });
 
-Cypress.Commands.add('checkOpenDrawer', (route) => {
+Cypress.Commands.add('checkOpenDrawer', () => {
     cy.getDataCy('drawer').should('not.exist');
-    cy.openDrawer(route);
+    cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
     cy.getDataCy('drawer').should('exist');
 });
 
+Cypress.Commands.add('checkDownloadedFile', (filename) => {
+    cy.readFile(`cypress/downloads/${filename}`);
+});
+
+// WIP - not working
 Cypress.Commands.add('checkValueCopiedToClipboard', (value) => {
     cy.window().then((win) => {
         win.navigator.clipboard.readText().then((text) => {

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -118,7 +118,7 @@ Cypress.Commands.add('checkOpenDrawer', () => {
  * filename - expects the filename as a string
  */
 Cypress.Commands.add('checkDownloadedFile', (filename) => {
-    cy.readFile(`cypress/downloads/${filename}`);
+    cy.readFile(`cypress/downloads/${filename}`, { timeout: 20000 });
 });
 
 // WIP - not working

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -120,12 +120,3 @@ Cypress.Commands.add('checkOpenDrawer', () => {
 Cypress.Commands.add('checkDownloadedFile', (filename) => {
     cy.readFile(`cypress/downloads/${filename}`, { timeout: 20000 });
 });
-
-// WIP - not working
-Cypress.Commands.add('checkValueCopiedToClipboard', (value) => {
-    cy.window().then((win) => {
-        win.navigator.clipboard.readText().then((text) => {
-            expect(text).to.eq(value);
-        });
-    });
-});

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -120,3 +120,25 @@ Cypress.Commands.add('checkOpenDrawer', () => {
 Cypress.Commands.add('checkDownloadedFile', (filename) => {
     cy.readFile(`cypress/downloads/${filename}`, { timeout: 20000 });
 });
+
+Cypress.Commands.add('checkSearchByKey', (asset) => {
+    cy.get('tbody[data-cy=loaded]').should('exist');
+    cy.getDataCy('items-count').then(($count) => {
+        const count = parseInt($count.text());
+        if (count > Cypress.env('DEFAULT_PAGE_SIZE')) {
+            cy.get('[data-key]')
+                .first()
+                .invoke('data', 'key')
+                .then((key) => {
+                    cy.getDataCy('search-bar').type(key);
+                    cy.getDataCy('search-item').click();
+                    cy.url().should(
+                        'include',
+                        asset === 'compute_plans'
+                            ? `/${asset}/${key}/tasks`
+                            : `/${asset}/${key}`
+                    );
+                });
+        }
+    });
+});

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -24,10 +24,15 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
+// get the data-cy attribute
 Cypress.Commands.add('getDataCy', (input) => {
     return cy.get(`[data-cy='${input}']`);
 });
 
+/**
+ * Login to the app using credentials in cypress env,
+ * then check if cookies have been set correctly.
+ */
 Cypress.Commands.add('login', () => {
     cy.session(
         'login',
@@ -49,6 +54,11 @@ Cypress.Commands.add('login', () => {
     );
 });
 
+/**
+ * Check the item count to see if there is several pages.
+ * If there is, test to go back & forth between page 1 & 2.
+ * First using next & previous buttons,then using number buttons.
+ */
 Cypress.Commands.add('paginationTest', () => {
     cy.getDataCy('items-count').then(($count) => {
         const count = parseInt($count.text());
@@ -64,6 +74,11 @@ Cypress.Commands.add('paginationTest', () => {
     });
 });
 
+/**
+ * Check the opening and closing of the filter modal.
+ * First by clicking the add filter button,
+ * then by clicking the filter button inside table column header menus
+ */
 Cypress.Commands.add('checkOpenFilters', (position) => {
     cy.getDataCy('filters-table').should('not.exist');
     cy.getDataCy('add-filter').click();
@@ -75,6 +90,10 @@ Cypress.Commands.add('checkOpenFilters', (position) => {
     cy.getDataCy('filters-table').should('be.visible');
 });
 
+/**
+ * Check if an asset table can be filtered by a given filter.
+ * filter - expects the name of the filter to test as a string
+ */
 Cypress.Commands.add('checkFilterAssetsBy', (filter) => {
     cy.getDataCy('add-filter').click();
     cy.getDataCy(`${filter}-filters`).click();
@@ -85,12 +104,19 @@ Cypress.Commands.add('checkFilterAssetsBy', (filter) => {
     cy.getDataCy(`${filter}-filter-tag`).should('exist');
 });
 
+/**
+ * Check if a drawer is correctly opened when clicking an asset in its table.
+ */
 Cypress.Commands.add('checkOpenDrawer', () => {
     cy.getDataCy('drawer').should('not.exist');
     cy.get('tbody[data-cy=loaded]').get('tr').eq(1).click({ force: true });
     cy.getDataCy('drawer').should('exist');
 });
 
+/**
+ * Check if a file of a given name has been correctly downloaded.
+ * filename - expects the filename as a string
+ */
 Cypress.Commands.add('checkDownloadedFile', (filename) => {
     cy.readFile(`cypress/downloads/${filename}`);
 });

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -49,7 +49,6 @@ Cypress.Commands.add('pagination_test', () => {
     cy.get('[data-cy=items-count]').then(($count) => {
         const count = parseInt($count.text());
         if (count > Cypress.env('DEFAULT_PAGE_SIZE')) {
-            cy.log('wtfffdfsghjerzinfgioejfeiozfjiozpqg');
             cy.get('[data-cy=active-page').invoke('text').should('eq', '1');
             cy.get('[data-cy=next-page]').click();
             cy.get('[data-cy=active-page').invoke('text').should('eq', '2');
@@ -59,4 +58,9 @@ Cypress.Commands.add('pagination_test', () => {
             cy.get('[data-cy=active-page').invoke('text').should('eq', '2');
         }
     });
+});
+
+Cypress.Commands.add('open_filters', () => {
+    cy.get('[data-cy=open-filters]').click();
+    cy.get('[data-cy=filters-table]').should('exist');
 });

--- a/e2e-tests/cypress/support/e2e.js
+++ b/e2e-tests/cypress/support/e2e.js
@@ -27,4 +27,15 @@ beforeEach(() => {
             password: Cypress.env('PASSWORD'),
         }
     );
+
+    /**
+     * keep uncaught exceptions from failing tests
+     * uncomment this function to test part with expected error
+     **/
+    // cy.on('uncaught:exception', (e, runnable) => {
+    //     console.log('error', e);
+    //     console.log('runnable', runnable);
+    //     console.log('error', e.message);
+    //     return false;
+    // });
 });

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -8,8 +8,8 @@
     "private": "true",
     "version": "0.1.0",
     "scripts": {
-        "test:e2e": "cypress run",
-        "cypress:open": "cypress open"
+        "cy:run": "cypress run",
+        "cy:open": "cypress open"
     },
     "dependencies": {
         "cypress": "13.1.0"

--- a/src/components/ComputePlanTaskStatuses.tsx
+++ b/src/components/ComputePlanTaskStatuses.tsx
@@ -11,7 +11,7 @@ const ComputePlanTaskStatuses = ({
 }: {
     computePlan: ComputePlanT;
 }): JSX.Element => (
-    <Flex gap="2.5" width="513px" wrap="wrap">
+    <Flex gap="2.5" width="513px" wrap="wrap" data-cy="cp-tasks-status-tooltip">
         {taskStatusOrder.map((status) => (
             <Status
                 key={status}

--- a/src/components/DownloadIconButton.tsx
+++ b/src/components/DownloadIconButton.tsx
@@ -38,6 +38,7 @@ const DownloadIconButton = ({
             fontSize="xs"
         >
             <IconButton
+                data-cy="download-button"
                 size="sm"
                 color="gray.500"
                 icon={<RiDownloadLine />}

--- a/src/components/DrawerSection.tsx
+++ b/src/components/DrawerSection.tsx
@@ -189,7 +189,9 @@ export const DrawerSectionKeyEntry = ({
             <Skeleton height="4" width="250px" />
         ) : (
             <HStack spacing={1.5}>
-                <Text flexGrow="1" data-cy="function-key">{value}</Text>
+                <Text flexGrow="1" data-cy="function-key">
+                    {value}
+                </Text>
                 <CopyIconButton
                     value={value}
                     aria-label={`Copy key`}

--- a/src/components/DrawerSection.tsx
+++ b/src/components/DrawerSection.tsx
@@ -189,12 +189,13 @@ export const DrawerSectionKeyEntry = ({
             <Skeleton height="4" width="250px" />
         ) : (
             <HStack spacing={1.5}>
-                <Text flexGrow="1">{value}</Text>
+                <Text flexGrow="1" data-cy="function-key">{value}</Text>
                 <CopyIconButton
                     value={value}
                     aria-label={`Copy key`}
                     variant="solid"
                     size="xs"
+                    data-cy="copy-function-key"
                 />
             </HStack>
         )}

--- a/src/components/PerfDownloadButton.tsx
+++ b/src/components/PerfDownloadButton.tsx
@@ -93,14 +93,23 @@ const PerfDownloadButton = (): JSX.Element => {
                 size="xs"
                 isDisabled={loading}
                 isLoading={downloading}
+                data-cy="download-button"
             >
                 Download
             </MenuButton>
             <MenuList zIndex="popover">
-                <MenuItem onClick={onDownloadImage} fontSize="xs">
+                <MenuItem
+                    onClick={onDownloadImage}
+                    fontSize="xs"
+                    data-cy="download-as-jpeg"
+                >
                     Download as JPEG
                 </MenuItem>
-                <MenuItem onClick={download} fontSize="xs">
+                <MenuItem
+                    onClick={download}
+                    fontSize="xs"
+                    data-cy="download-as-csv"
+                >
                     Download as CSV
                 </MenuItem>
             </MenuList>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -109,6 +109,7 @@ const Header = (): JSX.Element => {
             backgroundColor="white"
             flexShrink={0}
             transition="height 300ms ease-in-out"
+            data-user-role={userRole}
         >
             <HStack spacing="5">
                 <IconLink href={PATHS.HOME}>
@@ -160,6 +161,7 @@ const Header = (): JSX.Element => {
                             {userRole === 'ADMIN' && (
                                 <MenuItem
                                     onClick={() => setLocation(PATHS.USERS)}
+                                    data-cy="users-management"
                                 >
                                     Users
                                 </MenuItem>

--- a/src/components/layout/header/OmniSearch.tsx
+++ b/src/components/layout/header/OmniSearch.tsx
@@ -116,6 +116,7 @@ const AssetItem = ({
             backgroundColor={selected ? 'gray.100' : 'white'}
             cursor="pointer"
             {...itemProps}
+            data-cy="search-item"
         >
             <HStack spacing="4" alignItems="center">
                 <Flex
@@ -494,6 +495,7 @@ const OmniSearch = () => {
                         borderColor: 'primary.500',
                     }}
                     {...getInputProps()}
+                    data-cy="search-bar"
                 />
                 <InputRightElement>
                     {inputValue && <CloseButton size="sm" onClick={reset} />}

--- a/src/components/table/OrderingTh.tsx
+++ b/src/components/table/OrderingTh.tsx
@@ -155,6 +155,7 @@ const OrderingTh = ({ options, openFilters, ...props }: OrderingThProps) => {
                         }
                         variant="ghost"
                         size="xs"
+                        data-cy="th-menu-button"
                     />
                     <MenuList zIndex="popover" fontFamily="Inter">
                         {openFilters && (
@@ -164,6 +165,7 @@ const OrderingTh = ({ options, openFilters, ...props }: OrderingThProps) => {
                                         setTimeout(openFilters, 50);
                                     }}
                                     icon={<RiFilter3Fill />}
+                                    data-cy="open-filters"
                                 >
                                     Filter
                                 </MenuItem>

--- a/src/components/table/Pagination.tsx
+++ b/src/components/table/Pagination.tsx
@@ -36,6 +36,13 @@ const PageLink = ({
                 variant="outline"
                 size="sm"
                 disabled={isDisabled || activePage === page}
+                data-cy={
+                    activePage === page
+                        ? 'active-page'
+                        : page === 2
+                        ? 'second-page'
+                        : ''
+                }
             >
                 {page}
             </Button>
@@ -64,6 +71,7 @@ const PreviousPage = ({ page }: { page: number }): JSX.Element => {
                 size="sm"
                 aria-label="Previous Page"
                 icon={<RiArrowLeftLine />}
+                data-cy="previous-page"
             />
         </Link>
     );
@@ -95,6 +103,7 @@ const NextPage = ({
                 size="sm"
                 aria-label="Next Page"
                 icon={<RiArrowRightLine />}
+                data-cy="next-page"
             />
         </Link>
     );

--- a/src/components/table/TablePagination.tsx
+++ b/src/components/table/TablePagination.tsx
@@ -17,7 +17,12 @@ const TablePagination = ({
 
     return (
         <Flex justifyContent="space-between" alignItems="center" width="100%">
-            <Text color="gray.500" fontSize="xs" lineHeight="4">
+            <Text
+                color="gray.500"
+                fontSize="xs"
+                lineHeight="4"
+                data-cy="items-count"
+            >
                 {itemCount === 0 && `0 results`}
                 {itemCount === 1 &&
                     `1 result • ${firstIndex}-${lastIndex} shown`}

--- a/src/components/table/TasksTable.tsx
+++ b/src/components/table/TasksTable.tsx
@@ -343,6 +343,15 @@ const TasksTable = ({
                                                           )
                                                       )
                                             }
+                                            data-cy={
+                                                task.status === 'STATUS_DONE' &&
+                                                Object.values(
+                                                    task.function.outputs
+                                                )[0]?.kind ===
+                                                    'ASSET_PERFORMANCE'
+                                                    ? 'task-with-performance'
+                                                    : undefined
+                                            }
                                         >
                                             <Td>
                                                 <Status

--- a/src/features/perfBrowser/PerfCard.tsx
+++ b/src/features/perfBrowser/PerfCard.tsx
@@ -24,6 +24,7 @@ const PerfCard = ({
             _hover={{ borderColor: 'primary.500', borderWidth: 2 }}
             onClick={onClick}
             cursor="pointer"
+            data-cy="perf-card"
         >
             <Box flexGrow={1}>{children}</Box>
             <Tooltip label={title} fontSize="xs" hasArrow placement="bottom">

--- a/src/features/perfBrowser/PerfDetails.tsx
+++ b/src/features/perfBrowser/PerfDetails.tsx
@@ -32,6 +32,7 @@ const PerfDetails = ({ series }: PerfDetailsProps): JSX.Element => {
             overflow="hidden"
             height="100%"
             position="relative"
+            data-cy="perf-details"
         >
             <PerfEmptyState seriesGroups={series.length > 0 ? [series] : []} />
             {series.length > 0 && (

--- a/src/features/perfBrowser/PerfList.tsx
+++ b/src/features/perfBrowser/PerfList.tsx
@@ -19,6 +19,7 @@ const PerfList = ({ seriesGroups, onCardClick }: PerfListProps) => {
             spacing="4"
             padding="8"
             overflow="hidden"
+            data-cy="perf-list"
         >
             <PerfEmptyState seriesGroups={seriesGroups} />
             <Wrap spacing="3" justify="center">

--- a/src/features/perfBrowser/usePerfBrowser.ts
+++ b/src/features/perfBrowser/usePerfBrowser.ts
@@ -394,8 +394,12 @@ const usePerfBrowser = (
                 getOrganizationIndex: (
                     computePlanKey: string,
                     organizationId: string
-                ): string =>
-                    organizationIndexes[computePlanKey][organizationId],
+                ): string => {
+                    if (!Object.values(organizationIndexes).length) {
+                        return 'Loading';
+                    }
+                    return organizationIndexes[computePlanKey][organizationId];
+                },
                 getSerieIndex: (
                     computePlanKey: string,
                     serieId: string

--- a/src/features/tableFilters/TableFilterCheckboxes.tsx
+++ b/src/features/tableFilters/TableFilterCheckboxes.tsx
@@ -40,6 +40,7 @@ const TableFilterCheckboxes = ({
                         colorScheme="primary"
                         key={getOptionValue(option)}
                         alignItems="start"
+                        data-cy="filter-checkbox"
                     >
                         <Text fontSize="sm" lineHeight="1.2">
                             {getOptionLabel(option)}

--- a/src/features/tableFilters/TableFilterTags.tsx
+++ b/src/features/tableFilters/TableFilterTags.tsx
@@ -43,6 +43,11 @@ const FilterTag = ({ label, clear, ...props }: FilterTagProps): JSX.Element => (
             backgroundColor="white"
             color="gray.800"
             boxShadow="0 0 0px 1px var(--chakra-colors-gray-100)"
+            data-cy={
+                typeof label === 'string'
+                    ? `${label}-filter-tag`
+                    : `${label.props.title.toLowerCase()}-filter-tag`
+            }
             {...props}
         >
             <TagLabel>{label}</TagLabel>

--- a/src/features/tableFilters/TableFilters.tsx
+++ b/src/features/tableFilters/TableFilters.tsx
@@ -107,7 +107,7 @@ const TableFilters = ({ children }: TableFiltersProps): JSX.Element => {
                         size="sm"
                         backgroundColor="secondary"
                         leftIcon={<RiAddLine />}
-                        data-cy="open-filters"
+                        data-cy="add-filter"
                     >
                         Add Filter
                     </Button>
@@ -118,7 +118,10 @@ const TableFilters = ({ children }: TableFiltersProps): JSX.Element => {
                     data-cy="filters-table"
                 >
                     <PopoverArrow />
-                    <PopoverCloseButton onClick={onPopoverClose} />
+                    <PopoverCloseButton
+                        onClick={onPopoverClose}
+                        data-cy="close-filters-modal"
+                    />
                     <PopoverBody padding="0" overflow="hidden">
                         <Tabs
                             variant="soft-rounded"
@@ -147,6 +150,7 @@ const TableFilters = ({ children }: TableFiltersProps): JSX.Element => {
                                                 ? initialFocusRef
                                                 : null
                                         }
+                                        data-cy={`${tab.title.toLowerCase()}-filters`}
                                     >
                                         {tab.title}
                                         {isActive(tab.field) && (
@@ -194,6 +198,7 @@ const TableFilters = ({ children }: TableFiltersProps): JSX.Element => {
                                 color="white"
                                 colorScheme="primary"
                                 onClick={onApply}
+                                data-cy="filters-apply"
                             >
                                 Apply
                             </Button>

--- a/src/features/tableFilters/TableFilters.tsx
+++ b/src/features/tableFilters/TableFilters.tsx
@@ -107,11 +107,16 @@ const TableFilters = ({ children }: TableFiltersProps): JSX.Element => {
                         size="sm"
                         backgroundColor="secondary"
                         leftIcon={<RiAddLine />}
+                        data-cy="open-filters"
                     >
                         Add Filter
                     </Button>
                 </PopoverTrigger>
-                <PopoverContent minWidth="690px" boxShadow="xl">
+                <PopoverContent
+                    minWidth="690px"
+                    boxShadow="xl"
+                    data-cy="filters-table"
+                >
                     <PopoverArrow />
                     <PopoverCloseButton onClick={onPopoverClose} />
                     <PopoverBody padding="0" overflow="hidden">

--- a/src/routes/computePlanDetails/components/Actions.tsx
+++ b/src/routes/computePlanDetails/components/Actions.tsx
@@ -55,7 +55,14 @@ const Actions = ({
                 <IconButton
                     size="xs"
                     aria-label={ariaLabel}
-                    icon={favorite ? <RiStarFill /> : <RiStarLine />}
+                    icon={
+                        favorite ? (
+                            <RiStarFill data-cy="favorite-cp" />
+                        ) : (
+                            <RiStarLine />
+                        )
+                    }
+                    data-cy="favorite-box"
                     color={favorite ? 'primary' : 'gray'}
                     isDisabled={loading || !computePlan}
                     variant="outline"

--- a/src/routes/computePlanDetails/components/Actions.tsx
+++ b/src/routes/computePlanDetails/components/Actions.tsx
@@ -44,7 +44,7 @@ const Actions = ({
     });
 
     return (
-        <HStack paddingX="8">
+        <HStack paddingX="8" data-cpkey={computePlan?.key}>
             <Tooltip
                 label={ariaLabel}
                 fontSize="xs"

--- a/src/routes/computePlans/components/BulkSelection.tsx
+++ b/src/routes/computePlans/components/BulkSelection.tsx
@@ -92,6 +92,7 @@ const BulkSelection = ({
             alignItems="center"
             width="100%"
             color="white"
+            data-cy="selection-popover"
         >
             <HStack alignItems="baseline" spacing="5px" shouldWrapChildren>
                 <Popover placement="top-start">

--- a/src/routes/computePlans/components/ComputePlanTr.tsx
+++ b/src/routes/computePlans/components/ComputePlanTr.tsx
@@ -108,6 +108,7 @@ const ComputePlanTr = ({
                     })
                 )
             }
+            data-key={computePlan.key}
         >
             <CheckboxTd
                 firstCol={true}
@@ -120,6 +121,7 @@ const ComputePlanTr = ({
                     isChecked={isSelected}
                     onChange={onSelectionChange}
                     colorScheme="primary"
+                    data-cy="selection-box"
                 />
             </CheckboxTd>
             <CheckboxTd

--- a/src/routes/computePlans/components/FavoriteBox.tsx
+++ b/src/routes/computePlans/components/FavoriteBox.tsx
@@ -34,14 +34,12 @@ const FavoriteBox = ({
             transitionDuration="normal"
             data-cy="favorite-box"
         >
-            {!isChecked && (
-                <RiStarLine
-                    fill="var(--chakra-colors-gray-300)"
+            {!isChecked && <RiStarLine fill="var(--chakra-colors-gray-300)" />}
+            {isChecked && (
+                <RiStarFill
+                    fill="var(--chakra-colors-primary-500)"
                     data-cy="favorite-cp"
                 />
-            )}
-            {isChecked && (
-                <RiStarFill fill="var(--chakra-colors-primary-500)" />
             )}
             <StyledInput
                 type="checkbox"

--- a/src/routes/computePlans/components/FavoriteBox.tsx
+++ b/src/routes/computePlans/components/FavoriteBox.tsx
@@ -32,8 +32,14 @@ const FavoriteBox = ({
             boxShadow={focus ? 'outline' : undefined}
             transitionProperty="box-shadow"
             transitionDuration="normal"
+            data-cy="favorite-box"
         >
-            {!isChecked && <RiStarLine fill="var(--chakra-colors-gray-300)" />}
+            {!isChecked && (
+                <RiStarLine
+                    fill="var(--chakra-colors-gray-300)"
+                    data-cy="favorite-cp"
+                />
+            )}
             {isChecked && (
                 <RiStarFill fill="var(--chakra-colors-primary-500)" />
             )}

--- a/src/routes/computePlans/components/StatusCell.tsx
+++ b/src/routes/computePlans/components/StatusCell.tsx
@@ -22,7 +22,11 @@ const StatusCell = ({ computePlan }: StatusCellProps): JSX.Element => {
         <Popover trigger="hover" placement="bottom-start">
             <PopoverTrigger>
                 <VStack spacing="1" alignItems="stretch">
-                    <Flex alignItems="center" justifyContent="space-between">
+                    <Flex
+                        alignItems="center"
+                        justifyContent="space-between"
+                        data-cy="cp-tasks-status"
+                    >
                         <Status status={computePlan.status} size="sm" />
                         <Text fontSize="xs" color="gray.600">
                             {computePlan.done_count + computePlan.failed_count}/

--- a/src/routes/datasets/Datasets.tsx
+++ b/src/routes/datasets/Datasets.tsx
@@ -230,6 +230,7 @@ const Datasets = (): JSX.Element => {
                                 datasets.map((dataset) => (
                                     <ClickableTr
                                         key={dataset.key}
+                                        data-key={dataset.key}
                                         onClick={() =>
                                             setLocationPreserveParams(
                                                 compilePath(PATHS.DATASET, {

--- a/src/routes/functions/Functions.tsx
+++ b/src/routes/functions/Functions.tsx
@@ -225,7 +225,7 @@ const Functions = (): JSX.Element => {
                                     </Td>
                                 </TableSkeleton>
                             ) : (
-                                functions.map((func) => (
+                                functions?.map((func) => (
                                     <ClickableTr
                                         key={func.key}
                                         onClick={() =>

--- a/src/routes/functions/Functions.tsx
+++ b/src/routes/functions/Functions.tsx
@@ -29,6 +29,7 @@ import {
     useTableFiltersContext,
 } from '@/features/tableFilters/useTableFilters';
 import { useAssetListDocumentTitleEffect } from '@/hooks/useDocumentTitleEffect';
+import useHasPermission from '@/hooks/useHasPermission';
 import useKeyFromPath from '@/hooks/useKeyFromPath';
 import { useSetLocationPreserveParams } from '@/hooks/useLocationWithParams';
 import {
@@ -97,6 +98,7 @@ const Functions = (): JSX.Element => {
     ]);
 
     const key = useKeyFromPath(PATHS.FUNCTION);
+    const hasDownloadPermission = useHasPermission();
 
     const context = useTableFiltersContext('function');
     const { onPopoverOpen } = context;
@@ -234,6 +236,13 @@ const Functions = (): JSX.Element => {
                                                     key: func.key,
                                                 })
                                             )
+                                        }
+                                        data-cy={
+                                            hasDownloadPermission(
+                                                func.permissions.download
+                                            )
+                                                ? 'has-download-permissions'
+                                                : undefined
                                         }
                                     >
                                         <Td>

--- a/src/routes/functions/Functions.tsx
+++ b/src/routes/functions/Functions.tsx
@@ -230,6 +230,7 @@ const Functions = (): JSX.Element => {
                                 functions?.map((func) => (
                                     <ClickableTr
                                         key={func.key}
+                                        data-key={func.key}
                                         onClick={() =>
                                             setLocationPreserveParams(
                                                 compilePath(PATHS.FUNCTION, {

--- a/src/routes/functions/components/FunctionDrawer.tsx
+++ b/src/routes/functions/components/FunctionDrawer.tsx
@@ -109,6 +109,7 @@ const FunctionDrawer = (): JSX.Element => {
                                 func ? func.archive.storage_address : ''
                             }
                             filename={`function-${key}.zip`}
+                            data-filename={`function-${key}.zip`}
                             aria-label={
                                 func &&
                                 hasDownloadPermission(

--- a/src/routes/functions/components/FunctionDrawer.tsx
+++ b/src/routes/functions/components/FunctionDrawer.tsx
@@ -109,7 +109,6 @@ const FunctionDrawer = (): JSX.Element => {
                                 func ? func.archive.storage_address : ''
                             }
                             filename={`function-${key}.zip`}
-                            data-filename={`function-${key}.zip`}
                             data-fnkey={key}
                             aria-label={
                                 func &&

--- a/src/routes/functions/components/FunctionDrawer.tsx
+++ b/src/routes/functions/components/FunctionDrawer.tsx
@@ -110,6 +110,7 @@ const FunctionDrawer = (): JSX.Element => {
                             }
                             filename={`function-${key}.zip`}
                             data-filename={`function-${key}.zip`}
+                            data-fnkey={key}
                             aria-label={
                                 func &&
                                 hasDownloadPermission(

--- a/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
@@ -39,7 +39,7 @@ const displayPerformance = (value: number | null, taskStatus: TaskStatus) => {
             </Text>
         );
     } else {
-        return <>{value.toFixed(3)}</>;
+        return <Text fontSize="xs" data-cy="output-performance">{value.toFixed(3)}</Text>;
     }
 };
 

--- a/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
+++ b/src/routes/tasks/components/TaskOutputsDrawerSection.tsx
@@ -39,7 +39,11 @@ const displayPerformance = (value: number | null, taskStatus: TaskStatus) => {
             </Text>
         );
     } else {
-        return <Text fontSize="xs" data-cy="output-performance">{value.toFixed(3)}</Text>;
+        return (
+            <Text fontSize="xs" data-cy="output-performance">
+                {value.toFixed(3)}
+            </Text>
+        );
     }
 };
 

--- a/src/routes/users/Users.tsx
+++ b/src/routes/users/Users.tsx
@@ -179,6 +179,7 @@ const Users = (): JSX.Element => {
                             compilePath(PATHS.USER, { key: 'create' })
                         )
                     }
+                    data-cy="create-user"
                 >
                     Create user
                 </Button>
@@ -249,6 +250,8 @@ const Users = (): JSX.Element => {
                             users.map((user) => (
                                 <ClickableTr
                                     key={user.username}
+                                    data-name={user.username}
+                                    data-role={user.role}
                                     onClick={() =>
                                         setLocationPreserveParams(
                                             compilePath(PATHS.USER, {

--- a/src/routes/users/components/CreateUserForm.tsx
+++ b/src/routes/users/components/CreateUserForm.tsx
@@ -127,6 +127,7 @@ const CreateUserForm = ({
                             passwordHasErrors
                         }
                         isLoading={creatingUser}
+                        data-cy="submit-form"
                     >
                         Save
                     </Button>

--- a/src/routes/users/components/PasswordInput.tsx
+++ b/src/routes/users/components/PasswordInput.tsx
@@ -66,6 +66,7 @@ const PasswordInput = ({
                             setIsDirty(true);
                             onChange(newValue);
                         }}
+                        data-cy="password-input"
                     />
                     <InputRightElement>
                         <IconButton

--- a/src/routes/users/components/UpdateUserForm.tsx
+++ b/src/routes/users/components/UpdateUserForm.tsx
@@ -200,6 +200,7 @@ const UpdateUserForm = ({
                             icon={<RiDeleteBinLine />}
                             onClick={onConfirmOpen}
                             disabled={isDisabled}
+                            data-cy="delete-user"
                         />
                     </Tooltip>
                 }
@@ -237,6 +238,7 @@ const UpdateUserForm = ({
                                 ml="3"
                                 size="sm"
                                 isLoading={deletingUser}
+                                data-cy="confirm-delete"
                             >
                                 Delete user
                             </Button>
@@ -299,6 +301,7 @@ const UpdateUserForm = ({
                             colorScheme="primary"
                             onClick={onUpdate}
                             disabled={role === user?.role || isLastAdmin}
+                            data-cy="submit-form"
                         >
                             Update
                         </Button>

--- a/src/routes/users/components/UsernameInput.tsx
+++ b/src/routes/users/components/UsernameInput.tsx
@@ -39,6 +39,7 @@ const UsernameInput = ({
                         setIsDirty(true);
                         setHasErrors(e.target.value === '');
                     }}
+                    data-cy="username-input"
                 />
                 {hasErrors && isDirty && (
                     <FormErrorMessage>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

Adds a first batch of automated tests for the frontend to minimize the manual testing needed on it when releasing a new version of Substra.

*Important:* Needs a companion PR on substra-ci to change the default test to frontend[mnist] instead of sdk

Closes FL-520