### PR TITLE
feat: separate download function from execute task

### DIFF
--- a/changes/1520.added
+++ b/changes/1520.added
@@ -1,1 +1,1 @@
-Profiling step \`download_function\`
+Profiling step `download_function`

--- a/changes/1520.added
+++ b/changes/1520.added
@@ -1,0 +1,1 @@
+Profiling step \`download_function\`

--- a/src/routes/tasks/TasksUtils.tsx
+++ b/src/routes/tasks/TasksUtils.tsx
@@ -32,9 +32,9 @@ export const getStepInfo = (step: TaskStep): StepInfoT => {
         case TaskStep.functionDownloading:
             return {
                 title: 'Downloading function',
-                color: 'teal.500',
+                color: 'primary.500',
                 description:
-                    'If the image has been built on another node, the organization executing the task has to download the function from the other organization.',
+                    'If the function image has been built on another organisation, the organisation executing the task has to download the image from this other organisation.',
             };
         case TaskStep.taskExecution:
             return {

--- a/src/routes/tasks/TasksUtils.tsx
+++ b/src/routes/tasks/TasksUtils.tsx
@@ -29,6 +29,13 @@ export const getStepInfo = (step: TaskStep): StepInfoT => {
                 description:
                     'Get the assets (dataset, models) to the directory that will be shared with the task container.',
             };
+        case TaskStep.functionDownloading:
+            return {
+                title: 'Downloading function',
+                color: 'teal.500',
+                description:
+                    'If the image has been built on another node, the organization executing the task has to download the function from the other organization.',
+            };
         case TaskStep.taskExecution:
             return {
                 title: 'Task execution',

--- a/src/types/TasksTypes.ts
+++ b/src/types/TasksTypes.ts
@@ -121,6 +121,7 @@ export type TaskT = {
 export enum TaskStep {
     imageBuilding = 'build_image',
     inputsPreparation = 'prepare_inputs',
+    functionDownloading = 'download_function',
     taskExecution = 'task_execution',
     outputsSaving = 'save_outputs',
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

<!--- Describe your choices and changes in detail -->
Add a new  task profiling step, `download_function` when the function owner is different from the worker and that the worker needs to download the function from the builder

Close FL-1520

## Companion PR

- https://github.com/Substra/substra-backend/pull/883

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

-   Think to update CHANGELOG.md before merge if needed !
