### PR TITLE
chore: remove building from task profiling

### DIFF
--- a/changes/1517.removed
+++ b/changes/1517.removed
@@ -1,0 +1,1 @@
+Task profiling step `build_image`

--- a/src/routes/tasks/TasksUtils.tsx
+++ b/src/routes/tasks/TasksUtils.tsx
@@ -15,13 +15,6 @@ import { getAssetKindLabel } from '../functions/FunctionsUtils';
 
 export const getStepInfo = (step: TaskStep): StepInfoT => {
     switch (step) {
-        case TaskStep.imageBuilding:
-            return {
-                title: 'Image building',
-                color: 'primary.500',
-                description:
-                    'If the image is present in the local Docker image registry: do nothing. If not, download the algorithm from another node if needed, and build the image.',
-            };
         case TaskStep.inputsPreparation:
             return {
                 title: 'Inputs preparation',

--- a/src/types/TasksTypes.ts
+++ b/src/types/TasksTypes.ts
@@ -119,7 +119,6 @@ export type TaskT = {
 };
 
 export enum TaskStep {
-    imageBuilding = 'build_image',
     inputsPreparation = 'prepare_inputs',
     functionDownloading = 'download_function',
     taskExecution = 'task_execution',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Squash commit should follow: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

## Description

<!--- Describe your choices and changes in detail -->
Remove the task profiling step `build_image`. The function will get its own profiling with different steps in another contribution.

Fixes FL-1517

## Companion PR

- https://github.com/Substra/substra-backend/pull/884

## How to test

<!--- Provide some help tips to the technical reviewer -->

## Screenshots

<!-- add screenshots if appropriate or delete this section -->

## Notes for developers and reviewers:

-   Think to update CHANGELOG.md before merge if needed !
