### PR TITLE
chore: allow alpha charts publication

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -14,7 +14,14 @@ on:
       - "main"
     paths:
       - "charts/substra-frontend/**"
-  workflow_dispatch: {} # For running by hand from the web UI
+  workflow_dispatch:
+    inputs:
+      publish-alpha:
+        description: |
+          Publish alpha chart. Chart version must be X.Y.Z-alpha.N.
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -26,4 +33,5 @@ jobs:
     uses: substra/substra-gha-workflows/.github/workflows/helm.yml@main
     with:
       helm-repositories: ''
+      publish-alpha: ${{ inputs.publish-alpha == true }}
     secrets: inherit


### PR DESCRIPTION
Companion:

- https://github.com/Substra/substra-backend/pull/881
- https://github.com/Substra/orchestrator/pull/405
- https://github.com/Substra/substra-frontend/pull/333

Example of working worklfow (with fake publish):

- https://github.com/Substra/substra-backend/actions/runs/8628929572